### PR TITLE
implement bracket wizard UI for issue #81

### DIFF
--- a/src/Bets/Init/WorldCup2026/Tournament/Teams.elm
+++ b/src/Bets/Init/WorldCup2026/Tournament/Teams.elm
@@ -173,7 +173,7 @@ qatar =
         , "Khalid Muneer"
         , "Naif Al-Hadhrami"
         ]
-    , group = A
+    , group = B
     }
 
 
@@ -210,7 +210,7 @@ ecuador =
         , "Michael Estrada"
         , "Djorkaeff Reasco"
         ]
-    , group = A
+    , group = E
     }
 
 
@@ -244,7 +244,7 @@ senegal =
         , "Mame Thiam"
         , "Habib Diallo"
         ]
-    , group = A
+    , group = I
     }
 
 
@@ -292,7 +292,7 @@ netherlands =
         , "Noa Lang"
         , "Brian Brobbey"
         ]
-    , group = A
+    , group = F
     }
 
 
@@ -332,7 +332,7 @@ england =
         , "Tammy Abraham"
         , "Jarrod Bowen"
         ]
-    , group = B
+    , group = L
     }
 
 
@@ -391,7 +391,7 @@ usa =
         , "Taylor Booth"
         , "Cade Cowell"
         ]
-    , group = B
+    , group = D
     }
 
 
@@ -434,7 +434,7 @@ iran =
         , "Kaveh Rezaei"
         , "Shahab Zahedi"
         ]
-    , group = B
+    , group = G
     }
 
 
@@ -491,7 +491,7 @@ argentina =
         , "Giovanni Simeone"
         , "Alejandro Garnacho"
         ]
-    , group = C
+    , group = J
     }
 
 
@@ -532,7 +532,7 @@ saudi_arabia =
         , "Haitham Asiri"
         , "Abdullah Radif"
         ]
-    , group = C
+    , group = H
     }
 
 
@@ -572,7 +572,7 @@ mexico =
         , "Rogelio Funes Mori"
         , "Santiago Giménez"
         ]
-    , group = C
+    , group = A
     }
 
 
@@ -614,7 +614,7 @@ france =
         , "Randal Kolo Muani"
         , "Ousmane Dembélé"
         ]
-    , group = D
+    , group = I
     }
 
 
@@ -692,7 +692,7 @@ tunisia =
         , "Issam Jebali"
         , "Sayfallah Ltaief"
         ]
-    , group = D
+    , group = F
     }
 
 
@@ -749,7 +749,7 @@ spain =
         , "Nico Williams"
         , "Borja Iglesias"
         ]
-    , group = E
+    , group = H
     }
 
 
@@ -814,7 +814,7 @@ japan =
         , "Ayase Ueda"
         , "Daizen Maeda"
         ]
-    , group = E
+    , group = F
     }
 
 
@@ -858,7 +858,7 @@ belgium =
         , "Thorgan Hazard"
         , "Dodi Lukebakio"
         ]
-    , group = F
+    , group = G
     }
 
 
@@ -901,7 +901,7 @@ croatia =
         , "Marko Livaja"
         , "Antonio-Mirko Čolak"
         ]
-    , group = F
+    , group = L
     }
 
 
@@ -931,7 +931,7 @@ canada =
         , "Jacob Shaffelburg"
         , "Ayo Akinola"
         ]
-    , group = F
+    , group = B
     }
 
 
@@ -974,7 +974,7 @@ morocco =
         , "Ayoub El Kaabi"
         , "Soufiane Rahimi"
         ]
-    , group = F
+    , group = C
     }
 
 
@@ -1012,7 +1012,7 @@ switzerland =
         , "Dan Ndoye"
         , "Zeki Amdouni"
         ]
-    , group = G
+    , group = B
     }
 
 
@@ -1046,7 +1046,7 @@ brazil =
         , "Pedro"
         , "Rodrygo"
         ]
-    , group = G
+    , group = C
     }
 
 
@@ -1113,7 +1113,7 @@ portugal =
         , "Gonçalo Ramos"
         , "Vitinha"
         ]
-    , group = H
+    , group = K
     }
 
 
@@ -1177,7 +1177,7 @@ ghana =
         , "Ransford-Yeboah Königsdörffer"
         , "Ernest Nuamah"
         ]
-    , group = H
+    , group = L
     }
 
 
@@ -1278,7 +1278,7 @@ south_korea =
         , "Cho Young-wook"
         , "Kim Gun-hee"
         ]
-    , group = H
+    , group = A
     }
 
 team_a4 : TeamDatum

--- a/src/Form/Bracket.elm
+++ b/src/Form/Bracket.elm
@@ -1,16 +1,25 @@
 module Form.Bracket exposing (isComplete, isCompleteQualifiers, update, view)
 
 import Bets.Bet
-import Bets.Types exposing (Answer(..), Bet, Bracket(..), Candidate(..), CurrentSlot(..), Group(..), HasQualified(..), Winner(..))
+import Bets.Init
+import Bets.Types exposing (Answer(..), Bet, Bracket(..), Candidate(..), Group(..), HasQualified(..), Team, Winner(..))
 import Bets.Types.Answer.Bracket
 import Bets.Types.Bracket as B
-import Bets.Types.Candidate as Candidate
-import Element exposing (spacing)
-import Form.Bracket.Types exposing (BracketState(..), Msg(..), State, createState, initialQualifierView)
-import Form.Bracket.View exposing (viewCandidatesPanel, viewRings)
-import UI.Page exposing (page)
-import UI.Style exposing (ButtonSemantics(..))
-import UI.Text
+import Bets.Types.Group as Group
+import Element
+import Form.Bracket.Types
+    exposing
+        ( BracketState(..)
+        , Msg(..)
+        , RoundSelections
+        , SelectionRound(..)
+        , State
+        , addTeamToRound
+        , currentActiveRound
+        , removeTeamFromAll
+        )
+import Form.Bracket.View
+import List.Extra as Extra
 
 
 isComplete : Bet -> Bool
@@ -25,131 +34,250 @@ isCompleteQualifiers bet =
 
 update : Msg -> Bet -> State -> ( Bet, State, Cmd Msg )
 update msg bet state =
+    let
+        (BracketWizard wizardState) =
+            state.bracketState
+    in
     case msg of
-        SetWinner slot homeOrAway ->
+        SelectTeam round team ->
             let
-                newBet =
-                    Bets.Bet.setWinner bet slot homeOrAway
-            in
-            ( newBet, state, Cmd.none )
-
-        SetQualifier slot candidates ->
-            let
-                bracketState =
-                    ShowSecondRoundSelection slot candidates
-            in
-            ( bet, { state | bracketState = bracketState }, Cmd.none )
-
-        SetSlot slot cand grp team ->
-            let
-                cleanedBet =
-                    case cand of
-                        BestThirdFrom _ ->
-                            Bets.Bet.cleanThirds bet grp
-
-                        _ ->
-                            bet
-
-                newBet =
-                    Bets.Bet.setQualifier cleanedBet slot grp (Just team)
-
-                nextSlot =
-                    Bets.Bet.getBracket newBet
-                        |> B.getFreeSlots
-                        |> List.sortBy toSortable
-                        |> List.head
-
-                toSortable ( _, c ) =
-                    Candidate.toSortable c
+                newSelections =
+                    addTeamToRound round team wizardState.selections
 
                 newState =
-                    case nextSlot of
-                        Just ( s, c ) ->
-                            { state | bracketState = ShowSecondRoundSelection s c }
+                    { state | bracketState = BracketWizard { selections = newSelections } }
 
-                        Nothing ->
-                            state
+                newBracket =
+                    rebuildBracket newSelections Bets.Init.teamData
+
+                newBet =
+                    updateBracket bet newBracket
             in
             ( newBet, newState, Cmd.none )
 
-        CloseQualifierView ->
-            ( bet, { state | bracketState = ShowMatches }, Cmd.none )
-
-        OpenQualifierView ->
+        DeselectTeam team ->
             let
+                newSelections =
+                    removeTeamFromAll team wizardState.selections
+
                 newState =
-                    createQualifierView bet
-                        |> Maybe.map (createState state.screen)
-                        |> Maybe.withDefault (initialQualifierView state)
+                    { state | bracketState = BracketWizard { selections = newSelections } }
+
+                newBracket =
+                    rebuildBracket newSelections Bets.Init.teamData
+
+                newBet =
+                    updateBracket bet newBracket
             in
-            ( bet, newState, Cmd.none )
+            ( newBet, newState, Cmd.none )
 
-
-createQualifierView : Bet -> Maybe BracketState
-createQualifierView bet =
-    let
-        toSortable ( _, c ) =
-            Candidate.toSortable c
-    in
-    Bets.Bet.getBracket bet
-        |> B.getFreeSlots
-        |> List.sortBy toSortable
-        |> List.head
-        |> Maybe.map (\( s, c ) -> ShowSecondRoundSelection s c)
+        GoNext ->
+            ( bet, state, Cmd.none )
 
 
 view : Bet -> State -> Element.Element Msg
 view bet state =
+    Form.Bracket.View.view bet state
+
+
+
+-- Helpers
+
+
+updateBracket : Bet -> Bracket -> Bet
+updateBracket bet newBracket =
     let
-        bracket =
-            Bets.Bet.getBracket bet
+        newAnswers answers =
+            case answers.bracket of
+                Answer _ points ->
+                    { answers | bracket = Answer newBracket points }
+    in
+    { bet | answers = newAnswers bet.answers }
 
-        header =
-            UI.Text.displayHeader "Vul het schema in!"
 
-        introtext =
-            case state.bracketState of
-                ShowMatches ->
-                    [ Element.text "Dit is het knockout schema. In het midden staat de finale, daarboven en onder de ronden die daaraan voorafgaan. Klik op een land om het door te laten gaan naar de volgende ronde, net zo lang tot je een kampioen hebt."
+rebuildBracket : RoundSelections -> Bets.Types.TeamData -> Bracket
+rebuildBracket selections teamData =
+    let
+        emptyBracket =
+            Bets.Init.bet |> Bets.Bet.getBracket
+
+        -- Filter teams from lastThirtyTwo by group (preserving insertion order)
+        teamsInGroup : Group -> List Team
+        teamsInGroup grp =
+            List.filter
+                (\t -> List.any (\td -> td.team.teamID == t.teamID && td.group == grp) teamData)
+                selections.lastThirtyTwo
+
+        groups =
+            [ A, B, C, D, E, F, G, H, I, J, K, L ]
+
+        -- First and second place slot assignments
+        firstSecondAssignments : List ( String, Maybe Team )
+        firstSecondAssignments =
+            let
+                forGroup grp =
+                    let
+                        teams =
+                            teamsInGroup grp
+
+                        grpStr =
+                            Group.toString grp
+                    in
+                    [ ( "W" ++ grpStr, List.head teams )
+                    , ( "R" ++ grpStr, teams |> List.drop 1 |> List.head )
                     ]
+            in
+            List.concatMap forGroup groups
 
-                ShowSecondRoundSelection _ _ ->
-                    [ Element.text "Selecteer de landen voor de tweede ronde. De winnaar en de nummer 2 van elke poule gaan door."
-                    ]
+        -- Third-place teams (3rd in each group's lastThirtyTwo selection)
+        thirdPlaceTeams : List ( Group, Team )
+        thirdPlaceTeams =
+            let
+                forGroup grp =
+                    teamsInGroup grp
+                        |> List.drop 2
+                        |> List.head
+                        |> Maybe.map (\t -> ( grp, t ))
+            in
+            List.filterMap forGroup groups
 
-        introduction =
-            Element.paragraph (UI.Style.introduction []) introtext
+        -- Extract BestThird slot definitions from the initial empty bracket
+        bestThirdSlotDefs : List ( String, List Group )
+        bestThirdSlotDefs =
+            extractBestThirdSlots emptyBracket
 
-        extroduction =
-            Element.column (UI.Style.introduction [ spacing 16 ])
-                [ UI.Text.bulletText "1 punt voor ieder juist land in de tweede ronde. "
-                , UI.Text.bulletText "4 punten per kwartfinalist. "
-                , UI.Text.bulletText "7 punten per halve finalist. "
-                , UI.Text.bulletText "10 punten per finalist. "
-                , UI.Text.bulletText "13 punten voor de kampioen. "
-                ]
+        -- Greedily assign third-place teams to T slots
+        bestThirdAssignments : List ( String, Maybe Team )
+        bestThirdAssignments =
+            assignBestThirds thirdPlaceTeams bestThirdSlotDefs
 
-        candidatePanel =
-            case state.bracketState of
-                ShowSecondRoundSelection slot candidate ->
-                    viewCandidatesPanel bet bracket slot candidate
+        -- Step 1: fill all team slots
+        bracketWithTeams =
+            B.setBulk emptyBracket (firstSecondAssignments ++ bestThirdAssignments)
+
+        -- Match slot IDs by round
+        r1Slots =
+            [ "m73", "m74", "m75", "m76", "m77", "m78", "m79", "m80"
+            , "m81", "m82", "m83", "m84", "m85", "m86", "m87", "m88"
+            ]
+
+        r2Slots =
+            [ "m89", "m90", "m91", "m92", "m93", "m94", "m95", "m96" ]
+
+        r3Slots =
+            [ "m97", "m98", "m99", "m100" ]
+
+        r4Slots =
+            [ "m101", "m102" ]
+
+        r5Slots =
+            [ "m104" ]
+
+        championList =
+            selections.champion
+                |> Maybe.map List.singleton
+                |> Maybe.withDefault []
+
+        -- Steps 2-6: propagate winners through the bracket
+        bracketR1 =
+            setRoundWinners r1Slots selections.lastSixteen bracketWithTeams
+
+        bracketR2 =
+            setRoundWinners r2Slots selections.quarters bracketR1
+
+        bracketR3 =
+            setRoundWinners r3Slots selections.semis bracketR2
+
+        bracketR4 =
+            setRoundWinners r4Slots selections.finalists bracketR3
+
+        bracketR5 =
+            setRoundWinners r5Slots championList bracketR4
+    in
+    bracketR5
+
+
+extractBestThirdSlots : Bracket -> List ( String, List Group )
+extractBestThirdSlots bracket =
+    case bracket of
+        TeamNode slot (BestThirdFrom grps) _ _ ->
+            [ ( slot, grps ) ]
+
+        TeamNode _ _ _ _ ->
+            []
+
+        MatchNode _ _ home away _ _ ->
+            extractBestThirdSlots home ++ extractBestThirdSlots away
+
+
+assignBestThirds : List ( Group, Team ) -> List ( String, List Group ) -> List ( String, Maybe Team )
+assignBestThirds thirdTeams tSlots =
+    let
+        go remaining available acc =
+            case remaining of
+                [] ->
+                    List.map (\( s, _ ) -> ( s, Nothing )) available ++ acc
+
+                ( grp, team ) :: rest ->
+                    case Extra.findIndex (\( _, grps ) -> List.member grp grps) available of
+                        Just idx ->
+                            case Extra.getAt idx available of
+                                Just ( slot, _ ) ->
+                                    go rest (Extra.removeAt idx available) (( slot, Just team ) :: acc)
+
+                                Nothing ->
+                                    go rest available acc
+
+                        Nothing ->
+                            go rest available acc
+    in
+    go thirdTeams tSlots []
+
+
+setRoundWinners : List String -> List Team -> Bracket -> Bracket
+setRoundWinners slots nextRoundTeams bracket =
+    let
+        inNext t =
+            List.any (\nt -> nt.teamID == t.teamID) nextRoundTeams
+
+        setWinner slot br =
+            case B.get br slot of
+                Just (MatchNode _ _ home away _ _) ->
+                    let
+                        homeTeam_ =
+                            B.winner home
+
+                        awayTeam_ =
+                            B.winner away
+                    in
+                    case ( homeTeam_, awayTeam_ ) of
+                        ( Just ht, _ ) ->
+                            if inNext ht then
+                                B.proceed br slot HomeTeam
+
+                            else
+                                case awayTeam_ of
+                                    Just at ->
+                                        if inNext at then
+                                            B.proceed br slot AwayTeam
+
+                                        else
+                                            br
+
+                                    Nothing ->
+                                        br
+
+                        ( Nothing, Just at ) ->
+                            if inNext at then
+                                B.proceed br slot AwayTeam
+
+                            else
+                                br
+
+                        _ ->
+                            br
 
                 _ ->
-                    Element.none
-
-        -- viewToggle =
-        --     case state.bracketState of
-        --         ShowSecondRoundSelection _ _ ->
-        --             pill Active CloseQualifierView "naar het schema"
-        --         ShowMatches ->
-        --             pill Active OpenQualifierView "terug naar de tweede ronde"
+                    br
     in
-    page "bracket"
-        [ header
-        , introduction
-        , viewRings bet bracket state
-        , candidatePanel
-        , extroduction
-
-        -- , viewToggle
-        ]
+    List.foldl setWinner bracket slots

--- a/src/Form/Bracket/Types.elm
+++ b/src/Form/Bracket/Types.elm
@@ -1,53 +1,294 @@
-module Form.Bracket.Types exposing (Angle, BracketState(..), IsWinner(..), Msg(..), State, createState, init, initialKnockouts, initialQualifierView)
+module Form.Bracket.Types exposing
+    ( BracketState(..)
+    , IsWinner(..)
+    , Msg(..)
+    , RoundSelections
+    , SelectionRound(..)
+    , State
+    , WizardState
+    , addTeamToRound
+    , canSelectTeam
+    , countGroupInList
+    , currentActiveRound
+    , emptyRoundSelections
+    , init
+    , initialKnockouts
+    , isWizardComplete
+    , removeTeamFromAll
+    , roundRequired
+    , roundTeams
+    )
 
-import Bets.Types exposing (Bracket(..), Candidate(..), CurrentSlot(..), Group(..), HasQualified(..), Slot, Team, Winner(..))
+import Bets.Types exposing (Group, Team, TeamData)
 import UI.Screen as Screen
 
 
-type Msg
-    = SetWinner Slot Winner
-    | SetQualifier Slot Candidate
-    | SetSlot Slot Candidate Group Team
-    | CloseQualifierView
-    | OpenQualifierView
+type SelectionRound
+    = ChampionRound
+    | FinalistRound
+    | SemiRound
+    | QuarterRound
+    | LastSixteenRound
+    | LastThirtyTwoRound
 
 
-type alias Angle =
-    Float
+type alias RoundSelections =
+    { champion : Maybe Team
+    , finalists : List Team
+    , semis : List Team
+    , quarters : List Team
+    , lastSixteen : List Team
+    , lastThirtyTwo : List Team
+    }
 
 
-type IsWinner
-    = Yes
-    | No
-    | Undecided
-
-
-init : Screen.Size -> State
-init sz =
-    State sz <| ShowSecondRoundSelection "WA" (FirstPlace A)
-
-
-initialKnockouts : Screen.Size -> State
-initialKnockouts sz =
-    State sz ShowMatches
-
-
-initialQualifierView : State -> State
-initialQualifierView { screen } =
-    init screen
-
-
-createState : Screen.Size -> BracketState -> State
-createState sz bs =
-    State sz bs
+type alias WizardState =
+    { selections : RoundSelections }
 
 
 type BracketState
-    = ShowMatches
-    | ShowSecondRoundSelection Slot Candidate
+    = BracketWizard WizardState
 
 
 type alias State =
     { screen : Screen.Size
     , bracketState : BracketState
     }
+
+
+-- IsWinner is kept for backward compatibility with Bets.View.Bracket
+type IsWinner
+    = Yes
+    | No
+    | Undecided
+
+
+type Msg
+    = SelectTeam SelectionRound Team
+    | DeselectTeam Team
+    | GoNext
+
+
+emptyRoundSelections : RoundSelections
+emptyRoundSelections =
+    { champion = Nothing
+    , finalists = []
+    , semis = []
+    , quarters = []
+    , lastSixteen = []
+    , lastThirtyTwo = []
+    }
+
+
+init : Screen.Size -> State
+init sz =
+    { screen = sz
+    , bracketState = BracketWizard { selections = emptyRoundSelections }
+    }
+
+
+initialKnockouts : Screen.Size -> State
+initialKnockouts sz =
+    init sz
+
+
+roundRequired : SelectionRound -> Int
+roundRequired round =
+    case round of
+        ChampionRound ->
+            1
+
+        FinalistRound ->
+            2
+
+        SemiRound ->
+            4
+
+        QuarterRound ->
+            8
+
+        LastSixteenRound ->
+            16
+
+        LastThirtyTwoRound ->
+            32
+
+
+roundTeams : SelectionRound -> RoundSelections -> List Team
+roundTeams round sel =
+    case round of
+        ChampionRound ->
+            Maybe.map List.singleton sel.champion |> Maybe.withDefault []
+
+        FinalistRound ->
+            sel.finalists
+
+        SemiRound ->
+            sel.semis
+
+        QuarterRound ->
+            sel.quarters
+
+        LastSixteenRound ->
+            sel.lastSixteen
+
+        LastThirtyTwoRound ->
+            sel.lastThirtyTwo
+
+
+addTeamToRound : SelectionRound -> Team -> RoundSelections -> RoundSelections
+addTeamToRound round team sel =
+    let
+        addUnique t lst =
+            if List.any (\x -> x.teamID == t.teamID) lst then
+                lst
+
+            else
+                lst ++ [ t ]
+    in
+    case round of
+        ChampionRound ->
+            { champion = Just team
+            , finalists = addUnique team sel.finalists
+            , semis = addUnique team sel.semis
+            , quarters = addUnique team sel.quarters
+            , lastSixteen = addUnique team sel.lastSixteen
+            , lastThirtyTwo = addUnique team sel.lastThirtyTwo
+            }
+
+        FinalistRound ->
+            { sel
+                | finalists = addUnique team sel.finalists
+                , semis = addUnique team sel.semis
+                , quarters = addUnique team sel.quarters
+                , lastSixteen = addUnique team sel.lastSixteen
+                , lastThirtyTwo = addUnique team sel.lastThirtyTwo
+            }
+
+        SemiRound ->
+            { sel
+                | semis = addUnique team sel.semis
+                , quarters = addUnique team sel.quarters
+                , lastSixteen = addUnique team sel.lastSixteen
+                , lastThirtyTwo = addUnique team sel.lastThirtyTwo
+            }
+
+        QuarterRound ->
+            { sel
+                | quarters = addUnique team sel.quarters
+                , lastSixteen = addUnique team sel.lastSixteen
+                , lastThirtyTwo = addUnique team sel.lastThirtyTwo
+            }
+
+        LastSixteenRound ->
+            { sel
+                | lastSixteen = addUnique team sel.lastSixteen
+                , lastThirtyTwo = addUnique team sel.lastThirtyTwo
+            }
+
+        LastThirtyTwoRound ->
+            { sel | lastThirtyTwo = addUnique team sel.lastThirtyTwo }
+
+
+removeTeamFromAll : Team -> RoundSelections -> RoundSelections
+removeTeamFromAll team sel =
+    let
+        remove lst =
+            List.filter (\t -> t.teamID /= team.teamID) lst
+    in
+    { champion =
+        case sel.champion of
+            Just c ->
+                if c.teamID == team.teamID then
+                    Nothing
+
+                else
+                    Just c
+
+            Nothing ->
+                Nothing
+    , finalists = remove sel.finalists
+    , semis = remove sel.semis
+    , quarters = remove sel.quarters
+    , lastSixteen = remove sel.lastSixteen
+    , lastThirtyTwo = remove sel.lastThirtyTwo
+    }
+
+
+countGroupInList : Group -> List Team -> TeamData -> Int
+countGroupInList grp teams teamData =
+    let
+        inGroup t =
+            List.any (\td -> td.team.teamID == t.teamID && td.group == grp) teamData
+    in
+    List.filter inGroup teams
+        |> List.length
+
+
+canSelectTeam : SelectionRound -> Team -> RoundSelections -> TeamData -> Bool
+canSelectTeam round team sel teamData =
+    let
+        currentTeams =
+            roundTeams round sel
+
+        capacity =
+            roundRequired round
+
+        hasCapacity =
+            List.length currentTeams < capacity
+
+        notAlreadyInRound =
+            not (List.any (\t -> t.teamID == team.teamID) currentTeams)
+
+        groupConstraintOk =
+            let
+                alreadyInL32 =
+                    List.any (\t -> t.teamID == team.teamID) sel.lastThirtyTwo
+
+                teamGroup =
+                    List.head (List.filter (\td -> td.team.teamID == team.teamID) teamData)
+                        |> Maybe.map .group
+            in
+            case teamGroup of
+                Just grp ->
+                    alreadyInL32 || countGroupInList grp sel.lastThirtyTwo teamData < 3
+
+                Nothing ->
+                    True
+    in
+    hasCapacity && notAlreadyInRound && groupConstraintOk
+
+
+currentActiveRound : RoundSelections -> SelectionRound
+currentActiveRound sel =
+    let
+        championTeams =
+            Maybe.map List.singleton sel.champion |> Maybe.withDefault []
+
+        rounds =
+            [ ( ChampionRound, championTeams, 1 )
+            , ( FinalistRound, sel.finalists, 2 )
+            , ( SemiRound, sel.semis, 4 )
+            , ( QuarterRound, sel.quarters, 8 )
+            , ( LastSixteenRound, sel.lastSixteen, 16 )
+            , ( LastThirtyTwoRound, sel.lastThirtyTwo, 32 )
+            ]
+
+        isIncomplete ( _, teams, cap ) =
+            List.length teams < cap
+    in
+    rounds
+        |> List.filter isIncomplete
+        |> List.head
+        |> Maybe.map (\( r, _, _ ) -> r)
+        |> Maybe.withDefault LastThirtyTwoRound
+
+
+isWizardComplete : RoundSelections -> Bool
+isWizardComplete sel =
+    case sel.champion of
+        Just _ ->
+            List.length sel.lastThirtyTwo == 32
+
+        Nothing ->
+            False

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -4,6 +4,7 @@ import Bets.Bet
 import Bets.Types exposing (Group(..))
 import Element exposing (padding, paddingXY, px, spacing, width)
 import Form.Bracket
+import Form.Bracket.Types as BracketTypes
 import Form.GroupMatches
 import Form.Info
 import Form.Participant
@@ -43,7 +44,7 @@ view model =
 
 
 viewCard : Model Msg -> Int -> Card -> Element.Element Msg
-viewCard model _ card =
+viewCard model idx card =
     case card of
         IntroCard intro ->
             Element.map InfoMsg (Form.Info.view intro)
@@ -52,10 +53,19 @@ viewCard model _ card =
             Element.map (GroupMatchMsg groupMatchesState.group) (Form.GroupMatches.view model.bet groupMatchesState)
 
         BracketCard bracketState ->
-            Element.map BracketMsg (Form.Bracket.view model.bet bracketState)
+            let
+                next =
+                    Basics.min (idx + 1) (List.length model.cards - 1)
 
-        BracketKnockoutsCard bracketState ->
-            Element.map BracketMsg (Form.Bracket.view model.bet bracketState)
+                mapBracketMsg msg =
+                    case msg of
+                        BracketTypes.GoNext ->
+                            NavigateTo next
+
+                        other ->
+                            BracketMsg other
+            in
+            Element.map mapBracketMsg (Form.Bracket.view model.bet bracketState)
 
         TopscorerCard ->
             Element.map TopscorerMsg (Form.Topscorer.view model.bet)
@@ -87,9 +97,6 @@ viewPill model idx ( i, card ) =
 
                 BracketCard _ ->
                     mkpillModel (Form.Bracket.isCompleteQualifiers model.bet)
-
-                BracketKnockoutsCard _ ->
-                    mkpillModel (Form.Bracket.isComplete model.bet)
 
                 TopscorerCard ->
                     mkpillModel (Form.Topscorer.isComplete model.bet)

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -78,7 +78,6 @@ type Card
       -- | QuestionCard Questions.Model
     | GroupMatchesCard GroupMatches.State
     | BracketCard Bracket.State
-    | BracketKnockoutsCard Bracket.State
     | TopscorerCard
     | ParticipantCard
     | SubmitCard
@@ -259,7 +258,6 @@ initCards sz =
 
         otherCards =
             [ BracketCard <| Bracket.init sz
-            , BracketKnockoutsCard <| Bracket.initialKnockouts sz
             , TopscorerCard
             , ParticipantCard
             , SubmitCard


### PR DESCRIPTION
Replace the old slot-based qualifier/winner UI with a top-down wizard approach. Users now pick champion first, then finalists, semis, quarters, last16, and last32 teams. RoundSelections are rebuilt into a full Bracket tree on each selection via rebuildBracket/setRoundWinners.

Remove BracketKnockoutsCard — BracketCard now covers the full bracket. Fix WC2026 team group assignments (Qatar, Ecuador, Senegal, Netherlands, England, USA, Iran, Argentina, Saudi Arabia, Mexico, France, Tunisia, Spain, Japan, Belgium, Croatia, Canada, Morocco, Switzerland, Brazil, Portugal, Ghana, South Korea).