### PR TITLE
Group page: bottom nav, smaller pills, group labels

### DIFF
--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -304,14 +304,39 @@ viewCardChrome model card i =
         pillsArea =
             Element.column [ Element.spacing 4, Element.centerX ]
                 [ topPills, subPills ]
+
+        isGroupCard =
+            List.drop i model.cards
+                |> List.head
+                |> Maybe.map
+                    (\c ->
+                        case c of
+                            GroupMatchesCard _ ->
+                                True
+
+                            _ ->
+                                False
+                    )
+                |> Maybe.withDefault False
+
+        groupNav =
+            Element.row [ Element.spacing 20, Element.centerX ]
+                [ UI.Button.pillSmall UI.Style.Focus (NavigateTo prev) "vorige groep"
+                , UI.Button.pillSmall UI.Style.Focus (NavigateTo next) "volgende groep"
+                ]
+
+        columnAttrs =
+            [ padding 0
+            , spacing 30
+            , Element.centerX
+            , Element.width
+                (Element.fill
+                    |> Element.maximum (Screen.maxWidth model.screen)
+                )
+            ]
     in
-    Element.column
-        [ padding 0
-        , spacing 30
-        , Element.centerX
-        , Element.width
-            (Element.fill
-                |> Element.maximum (Screen.maxWidth model.screen)
-            )
-        ]
-        [ pillsArea, nav, card ]
+    if isGroupCard then
+        Element.column columnAttrs [ pillsArea, card, groupNav ]
+
+    else
+        Element.column columnAttrs [ pillsArea, nav, card ]

--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -5,6 +5,7 @@ module UI.Button exposing
     , maybeTeamBadgeSmall
     , navlink
     , pill
+    , pillSmall
     , submit
     , teamBadge
     , teamBadgeVerySmall
@@ -15,6 +16,7 @@ import Bets.Types
 import Element exposing (Element, alignLeft, alignRight, centerX, centerY, fill, height, padding, paddingXY, px, spacing, text, width)
 import Element.Border exposing (rounded)
 import Element.Events exposing (onClick)
+import Element.Font as Font
 import UI.Style as Style exposing (ButtonSemantics)
 import UI.Team
 
@@ -50,6 +52,15 @@ pill semantics msg buttonText =
     let
         buttonLayout =
             Style.button semantics [ paddingXY 4 4, height (px 30), onClick msg, centerY, centerX ]
+    in
+    Element.column buttonLayout [ Element.el [] (text buttonText) ]
+
+
+pillSmall : ButtonSemantics -> msg -> String -> Element msg
+pillSmall semantics msg buttonText =
+    let
+        buttonLayout =
+            Style.button semantics [ paddingXY 4 2, height (px 22), onClick msg, centerY, centerX, Font.size 11 ]
     in
     Element.column buttonLayout [ Element.el [] (text buttonText) ]
 


### PR DESCRIPTION
## Summary

- On `GroupMatchesCard` pages, the prev/next navigation is now placed **below** the card content instead of above
- Navigation buttons use a smaller pill style (22px height, font size 11) via the new `pillSmall` component
- Labels changed to **"vorige groep"** / **"volgende groep"** for clarity
- Non-group pages (bracket, topscorer, participant, submit) are unchanged

## Changes

- `src/UI/Button.elm`: add `pillSmall` function (smaller height + font size than `pill`)
- `src/Form/View.elm`: detect `GroupMatchesCard` in `viewCardChrome`, conditionally render group nav at the bottom

## Test plan

- [ ] Navigate to a group card → prev/next buttons appear **below** the matches, labeled "vorige groep" / "volgende groep", visibly smaller than the top section pills
- [ ] Navigate to a non-group card (bracket, topscorer, etc.) → prev/next remain **above** the card, labeled "vorige" / "volgende", full size
- [ ] `make debug` compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)