### PR TITLE
Terminal UI redesign (#86): text-based nav, score inputs, and mobile layout fixes

### DIFF
--- a/src/Form/GroupMatches.elm
+++ b/src/Form/GroupMatches.elm
@@ -6,13 +6,17 @@ import Bets.Types.Answer.GroupMatches as GroupMatches
 import Bets.Types.Group as G
 import Bets.Types.Match as M
 import Bets.Types.Score as S
+import Bets.Types.Team as T
 import Element exposing (centerX, centerY, fill, height, padding, paddingXY, px, spacing, width)
 import Element.Border as Border
 import Element.Events
+import Element.Font as Font
 import Element.Input as Input
 import Form.GroupMatches.Types exposing (ChangeCursor(..), Msg(..), State, updateCursor)
 import List.Extra exposing (groupsOf)
 import UI.Button.Score exposing (displayScore)
+import UI.Color as Color
+import UI.Font
 import UI.Match
 import UI.Page exposing (page)
 import UI.Style
@@ -116,10 +120,10 @@ viewInput _ matchID homeTeam awayTeam mScore =
                     , placeholder = Just (Input.placeholder [] (Element.text v))
                     }
             in
-            Input.text (UI.Style.scoreInput [ width (px 45), Border.rounded 5 ]) inp
+            Input.text (UI.Style.scoreInput [ width (px 45), Border.rounded 0 ]) inp
 
         wrap fld =
-            Element.el (UI.Style.wrapper [ width (px 34), centerX, centerY ]) fld
+            Element.el (UI.Style.wrapper [ centerX, centerY ]) fld
 
         extractScore extractor =
             mScore
@@ -136,14 +140,18 @@ viewInput _ matchID homeTeam awayTeam mScore =
                 |> wrap
 
         homeBadge =
-            UI.Team.viewTeamFull homeTeam
+            Element.el [ Font.color Color.white, UI.Font.mono, Font.size (UI.Font.scaled 1), centerY ]
+                (Element.text (T.display homeTeam))
 
         awayBadge =
-            UI.Team.viewTeamFull awayTeam
+            Element.el [ Font.color Color.white, UI.Font.mono, Font.size (UI.Font.scaled 1), centerY ]
+                (Element.text (T.display awayTeam))
     in
-    Element.row (UI.Style.activeMatch [ centerX, padding 20, spacing 20 ])
-        [ homeBadge
+    Element.row (UI.Style.activeMatch [ centerX, paddingXY 4 16, spacing 8 ])
+        [ Element.el [ Font.color Color.orange, UI.Font.mono, centerY ] (Element.text ">")
+        , homeBadge
         , homeInput
+        , Element.el [ Font.color Color.grey, UI.Font.mono, centerY ] (Element.text "-")
         , awayInput
         , awayBadge
         ]
@@ -151,18 +159,55 @@ viewInput _ matchID homeTeam awayTeam mScore =
 
 displayMatches3x1 : MatchID -> List ( MatchID, AnswerGroupMatch ) -> Element.Element Msg
 displayMatches3x1 cursor matches =
+    Element.column [ centerX, centerY, spacing 4 ]
+        (List.map (viewMatchLine cursor) matches)
+
+
+viewMatchLine : MatchID -> ( MatchID, AnswerGroupMatch ) -> Element.Element Msg
+viewMatchLine cursor ( answerId, Answer (GroupMatch _ match mScore) _ ) =
     let
-        display =
-            displayMatchFullRow cursor
+        home =
+            M.homeTeam match |> T.display
 
-        rows =
-            matches
+        away =
+            M.awayTeam match |> T.display
 
-        row match_ =
-            Element.row (UI.Style.matches [ spacing 20 ]) (List.filterMap display [ match_ ])
+        h =
+            mScore |> Maybe.andThen S.homeScore |> Maybe.map String.fromInt |> Maybe.withDefault "_"
+
+        a =
+            mScore |> Maybe.andThen S.awayScore |> Maybe.map String.fromInt |> Maybe.withDefault "_"
+
+        scoreStr =
+            h ++ "-" ++ a
+
+        cursorStr =
+            if cursor == answerId then
+                "  <"
+
+            else
+                ""
+
+        line =
+            String.padRight 4 ' ' home
+                ++ scoreStr
+                ++ "  "
+                ++ String.padRight 4 ' ' away
+                ++ cursorStr
     in
-    --
-    Element.column [ centerX, centerY, spacing 20 ] (List.map row matches)
+    Element.el
+        [ Element.Events.onClick (SelectMatch answerId)
+        , Element.pointer
+        , Font.color
+            (if cursor == answerId then
+                Color.orange
+
+             else
+                Color.white
+            )
+        , UI.Font.mono
+        ]
+        (Element.text line)
 
 
 displayMatches3x2 : MatchID -> List ( MatchID, AnswerGroupMatch ) -> Element.Element Msg

--- a/src/Form/Participant.elm
+++ b/src/Form/Participant.elm
@@ -8,18 +8,22 @@ import Bets.Bet exposing (setParticipant)
 import Bets.Types exposing (Bet, StringField(..))
 import Bets.Types.Participant
 import Bets.Types.StringField as StringField
-import Element exposing (fill, height, paddingXY, px, spacing, width)
+import Element exposing (centerX, fill, height, paddingEach, paddingXY, px, spacing, width)
+import Element.Font as Font
 import Element.Input
 import Email
-import Form.Participant.Types exposing (Attr(..), Msg(..))
+import Form.Participant.Types exposing (Attr(..), FieldTag(..), Msg(..), State)
+import Html.Events
+import UI.Color as Color
+import UI.Font
 import UI.Page exposing (page)
 import UI.Screen as Screen
 import UI.Style
 import UI.Text
 
 
-update : Msg -> Bet -> ( Bet, Cmd Msg )
-update msg bet =
+update : Msg -> State -> Bet -> ( Bet, State, Cmd Msg )
+update msg state bet =
     let
         toStringField s =
             if s == "" then
@@ -65,25 +69,34 @@ update msg bet =
                 newNewBet =
                     newBet attr bet.participant
             in
-            ( newNewBet, Cmd.none )
+            ( newNewBet, state, Cmd.none )
+
+        FocusField tag ->
+            ( bet, { state | activeField = Just tag }, Cmd.none )
+
+        BlurField ->
+            ( bet, { state | activeField = Nothing }, Cmd.none )
 
 
-view : Bet -> Element.Element Msg
-view bet =
+view : State -> Bet -> Element.Element Msg
+view state bet =
     let
         keys =
             [ Name, Postal, Residence, Email, Phone, Knows ]
 
+        fieldTags =
+            [ NameTag, PostalTag, ResidenceTag, EmailTag, PhoneTag, KnowsTag ]
+
+        labels =
+            [ "Naam", "Adres", "Woonplaats", "Email", "Telefoonnummer", "Waar ken je ons van?" ]
+
         values p =
             [ p.name, p.address, p.residence, p.email, p.phone, p.howyouknowus ]
 
-        placeholder p =
-            Element.Input.placeholder [] (Element.text p)
-
-        inputField ( k, v ) =
+        inputField tag ( k, ( lbl, sf ) ) =
             let
                 ( stringVal, hasError ) =
-                    case Tuple.second v of
+                    case sf of
                         Initial s ->
                             ( s, False )
 
@@ -93,20 +106,69 @@ view bet =
                         Error s ->
                             ( s, True )
 
+                isActive =
+                    state.activeField == Just tag
+
+                promptChar =
+                    if hasError then
+                        "!"
+
+                    else if isActive then
+                        ">"
+
+                    else
+                        "-"
+
+                promptColor =
+                    if hasError then
+                        Color.red
+
+                    else if isActive then
+                        Color.orange
+
+                    else
+                        Color.grey
+
                 inp =
                     { onChange = \val -> Set (k val)
                     , text = stringVal
-                    , label = UI.Text.labelText (Tuple.first v)
-                    , placeholder = Just (placeholder (Tuple.first v))
+                    , label = Element.Input.labelHidden lbl
+                    , placeholder = Nothing
                     }
             in
-            Element.Input.text (UI.Style.textInput hasError [ width (px 260), height (px 36) ]) inp
+            Element.column [ Element.spacing 4, width fill ]
+                [ Element.row [ Element.spacing 8 ]
+                    [ Element.el
+                        [ Element.width (px 16)
+                        , Font.color promptColor
+                        , UI.Font.mono
+                        ]
+                        (Element.text promptChar)
+                    , Element.el
+                        [ Font.color promptColor
+                        , UI.Font.mono
+                        , Font.size (UI.Font.scaled 1)
+                        ]
+                        (Element.text lbl)
+                    ]
+                , Element.el
+                    [ paddingEach { left = 24, top = 0, bottom = 0, right = 0 } ]
+                    (Element.Input.text
+                        (UI.Style.terminalInput hasError
+                            [ width fill
+                            , Element.htmlAttribute (Html.Events.onFocus (FocusField tag))
+                            , Element.htmlAttribute (Html.Events.onBlur BlurField)
+                            ]
+                        )
+                        inp
+                    )
+                ]
 
         lines =
             values bet.participant
-                |> List.map2 (\a b -> ( a, b )) [ "Naam", "Adres", "Woonplaats", "Email", "Telefoonnummer", "Waar ken je ons van?" ]
-                |> List.map2 (\a b -> ( a, b )) keys
-                |> List.map inputField
+                |> List.map2 Tuple.pair labels
+                |> List.map2 Tuple.pair keys
+                |> List.map2 (\tag ( k, ( lbl, sf ) ) -> inputField tag ( k, ( lbl, sf ) )) fieldTags
 
         header =
             UI.Text.displayHeader "Wie ben jij"


### PR DESCRIPTION
## Summary

- Replace pill-based form navigation with terminal-style checkboxes (`[x]`/`[.]`/`[ ]`) and a `stap N/M` step counter
- Replace flag badges in group match input with `T.display` 3-letter text codes — fits comfortably within mobile card width (~260px)
- Stack participant form fields vertically (label above, `width fill` input below) to eliminate fixed-pixel overflow on small screens
- Add `>` prompt prefix, `-` separator, and `<` cursor indicator to group match input row for terminal aesthetic
- Fix score input wrapper: remove `width (px 34)` outer that overflowed the `px 45` inner `Input.text`
- Add `UI.Button` score button styling: transparent background, grey text, orange on hover

## Test plan

- [ ] Build passes: `make debug`
- [ ] On 375px viewport: participant card shows label line + input below with no horizontal scroll
- [ ] On 375px viewport: group match active row (`> NED [_] - [_] SEN`) fits on one line
- [ ] Score inputs render without content bleeding outside cells
- [ ] Form navigation checkboxes reflect completion state correctly
- [ ] Desktop (1024px+): layout looks reasonable

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)