### PR TITLE
Terminal UI redesign: text-based nav, styling, and activity log format

### DIFF
--- a/src/Activities.elm
+++ b/src/Activities.elm
@@ -3,6 +3,7 @@ module Activities exposing (..)
 import Element exposing (Length, alignLeft, alignRight, column, fill, height, paddingXY, px, row, spacingXY, width)
 import Element.Border as Border exposing (rounded)
 import Element.Events as Events
+import Element.Font as Font
 import Element.Input as Input
 import Http
 import Json.Decode exposing (Decoder, andThen, field)
@@ -13,6 +14,8 @@ import RemoteData.Http as Web exposing (defaultConfig)
 import Time
 import Types exposing (ActivitiesModel, Activity(..), ActivityMeta, Comment, Msg(..), Post)
 import UI.Button
+import UI.Color as Color
+import UI.Font
 import UI.Screen as Screen
 import UI.Style
 import UI.Text
@@ -95,26 +98,36 @@ viewActivity tz activity =
 blogBox : String -> String -> String -> Time.Zone -> Time.Posix -> Element.Element Msg
 blogBox author title blog tz dt =
     column
-        (UI.Style.normalBox [ paddingXY 0 20, Screen.className "blogBox" ])
-        [ Element.paragraph (UI.Style.header2 []) [ Element.text title ]
+        [ paddingXY 0 8
+        , width fill
+        , Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
+        , Border.color Color.terminalBorder
+        , Screen.className "blogBox"
+        ]
+        [ row [ Element.spacing 8 ]
+            [ Element.el [ Font.color Color.grey, UI.Font.mono ] (Element.text (UI.Text.timeText tz dt))
+            , Element.el [ Font.color Color.orange, UI.Font.mono ] (Element.text ("## " ++ title))
+            ]
         , blogView blog
-        , Element.el (UI.Style.attribution [ alignRight ]) (Element.text (author ++ ", " ++ UI.Text.dateText tz dt))
+        , Element.el [ alignRight, Font.color Color.grey, UI.Font.mono ]
+            (Element.text ("-- " ++ author ++ ", " ++ UI.Text.dateText tz dt))
         ]
 
 
 commentBox : String -> String -> Time.Zone -> Time.Posix -> Element.Element Msg
 commentBox author comment tz dt =
     column
-        (UI.Style.darkBox [ paddingXY 0 20, Border.rounded 13, Screen.className "commentBox" ])
-        [ row
-            [ alignLeft ]
-            [ Element.el (UI.Style.attribution []) (Element.text (author ++ " zegt:")) ]
-        , row
-            [ alignLeft ]
-            [ commentView comment ]
-        , row
-            [ alignRight ]
-            [ timeView tz dt ]
+        [ paddingXY 0 8
+        , width fill
+        , Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
+        , Border.color Color.terminalBorder
+        , Screen.className "commentBox"
+        ]
+        [ row [ Element.spacing 8 ]
+            [ Element.el [ Font.color Color.grey, UI.Font.mono ] (Element.text (UI.Text.timeText tz dt))
+            , Element.el [ Font.color Color.orange, UI.Font.mono ] (Element.text (author ++ ":"))
+            ]
+        , commentView comment
         ]
 
 
@@ -138,10 +151,6 @@ commentView c =
     Element.paragraph (UI.Style.introduction []) [ comment ]
 
 
-timeView : Time.Zone -> Time.Posix -> Element.Element Msg
-timeView tz dt =
-    Element.el (UI.Style.attribution []) (Element.text (UI.Text.dateText tz dt))
-
 
 viewCommentInput : ActivitiesModel Msg -> Element.Element Msg
 viewCommentInput model =
@@ -156,7 +165,7 @@ viewCommentInput model =
                     , spellcheck = True
                     }
             in
-            Input.multiline [ height (px 120), Border.rounded 18 ] area
+            Input.multiline [ height (px 120), Border.rounded 0 ] area
 
         commentInputTrap =
             let
@@ -170,7 +179,7 @@ viewCommentInput model =
             Input.text
                 [ Events.onFocus ShowCommentInput
                 , height (px 48)
-                , Border.rounded 18
+                , Border.rounded 0
                 ]
                 area
 
@@ -185,7 +194,7 @@ viewCommentInput model =
             in
             Input.text
                 [ height (px 48)
-                , Border.rounded 18
+                , Border.rounded 0
                 ]
                 area
 
@@ -228,7 +237,7 @@ viewPostInput model =
                     , label = UI.Text.labelText "titel"
                     }
             in
-            Input.text [ height (px 36), Border.rounded 18 ] area
+            Input.text [ height (px 36), Border.rounded 0 ] area
 
         postInput v =
             let
@@ -240,7 +249,7 @@ viewPostInput model =
                     , spellcheck = True
                     }
             in
-            Input.multiline [ height (px 200), Border.rounded 18 ] area
+            Input.multiline [ height (px 200), Border.rounded 0 ] area
 
         postInputTrap =
             let
@@ -251,7 +260,7 @@ viewPostInput model =
                     , placeholder = Nothing
                     }
             in
-            Input.text [ Events.onFocus ShowPostInput, height (px 36), Border.rounded 18 ] area
+            Input.text [ Events.onFocus ShowPostInput, height (px 36), Border.rounded 0 ] area
 
         passphraseInput v =
             let
@@ -262,7 +271,7 @@ viewPostInput model =
                     , placeholder = Nothing
                     }
             in
-            Input.text [ height (px 36), Border.rounded 18 ] area
+            Input.text [ height (px 36), Border.rounded 0 ] area
 
         authorInput v =
             let
@@ -273,7 +282,7 @@ viewPostInput model =
                     , placeholder = Nothing
                     }
             in
-            Input.text [ height (px 36), Border.rounded 18 ] area
+            Input.text [ height (px 36), Border.rounded 0 ] area
 
         saveButton =
             if (model.post.msg == "") || (model.post.author == "") || (model.post.passphrase == "") then

--- a/src/Form/Bracket/View.elm
+++ b/src/Form/Bracket/View.elm
@@ -3,11 +3,13 @@ module Form.Bracket.View exposing (view)
 import Bets.Init
 import Bets.Types exposing (Bet, Group(..), Team, TeamData)
 import Bets.Types.Group as Group
+import Bets.Types.Team as T
 import Element exposing (Element, centerX, spacing)
 import Element.Events
 import Element.Font as Font
 import List.Extra
 import UI.Color as Color
+import UI.Font
 import Form.Bracket.Types
     exposing
         ( BracketState(..)
@@ -85,23 +87,48 @@ viewRoundStepper activeRound sel =
         isComplete r =
             List.length (roundTeams r sel) >= roundRequired r
 
-        stepStyle r =
-            if isComplete r then
-                UI.Style.PillA
-
-            else if r == activeRound then
-                UI.Style.PillB
+        labelColor r =
+            if isComplete r || r == activeRound then
+                Color.orange
 
             else
-                UI.Style.Pill
+                Color.grey
+
+        dotChar r =
+            if isComplete r then
+                "x"
+
+            else
+                "."
+
+        dotColor r =
+            if isComplete r then
+                Color.green
+
+            else if r == activeRound then
+                Color.orange
+
+            else
+                Color.grey
 
         viewStep ( r, label ) =
-            Element.el
-                (UI.Style.button (stepStyle r) [ Element.paddingXY 8 4 ])
-                (Element.text label)
+            Element.column [ Element.spacing 2, Element.width (Element.px 32) ]
+                [ Element.el [ Font.color (labelColor r), UI.Font.mono, Element.centerX ]
+                    (Element.text label)
+                , Element.el [ Font.color (dotColor r), UI.Font.mono, Element.centerX ]
+                    (Element.text (dotChar r))
+                ]
+
+        connector =
+            Element.column [ Element.spacing 2 ]
+                [ Element.el [ Font.color Color.grey, UI.Font.mono ]
+                    (Element.text " --- ")
+                , Element.el [ Font.color Color.grey, UI.Font.mono ]
+                    (Element.text "     ")
+                ]
     in
-    Element.row [ spacing 8, centerX ]
-        (List.map viewStep allRounds)
+    Element.row [ spacing 0, centerX ]
+        (List.intersperse connector (List.map viewStep allRounds))
 
 
 viewRoundSection : SelectionRound -> RoundSelections -> List Group -> TeamData -> SelectionRound -> Element Msg
@@ -141,7 +168,7 @@ viewRoundSection activeRound sel allGroups teamData_ round =
         remainingEl =
             if remaining > 0 then
                 [ Element.el
-                    (UI.Style.button UI.Style.Potential [ Element.paddingXY 6 4 ])
+                    [ Font.color Color.grey, UI.Font.mono ]
                     (Element.text ("+" ++ String.fromInt remaining))
                 ]
 
@@ -155,7 +182,7 @@ viewRoundSection activeRound sel allGroups teamData_ round =
 
                 rows =
                     List.Extra.greedyGroupsOf 8 items
-                        |> List.map (\chunk -> Element.row [ spacing 4 ] chunk)
+                        |> List.map (\chunk -> Element.row [ spacing 8 ] chunk)
             in
             if List.isEmpty items then
                 Element.none
@@ -222,29 +249,30 @@ viewGroup round selections placed teamData_ grp =
         isPlaced t =
             List.any (\p -> p.teamID == t.teamID) placed
 
-        blank =
-            Element.el [ Element.width (Element.px 32), Element.height (Element.px 38) ] Element.none
-
-        viewBadgeOrBlank t =
+        viewTeamOrBlank t =
             if isPlaced t then
-                blank
+                Element.el [ Font.color Color.grey, UI.Font.mono ] (Element.text "---")
 
             else
                 viewTeamBadge round selections teamData_ t
 
         label =
-            Element.el [ Element.width (Element.px 64), Element.paddingEach { top = 0, bottom = 0, left = 0, right = 12 }, Font.color Color.primaryText ]
-                (Element.text ("Groep " ++ Group.toString grp))
+            Element.el
+                [ Font.color Color.primaryText
+                , UI.Font.mono
+                , Element.paddingEach { top = 0, bottom = 0, left = 0, right = 8 }
+                ]
+                (Element.text (Group.toString grp ++ ":"))
 
-        badges =
-            List.map viewBadgeOrBlank allTeams
+        teamCodes =
+            List.map viewTeamOrBlank allTeams
     in
     if List.all isPlaced allTeams then
         Element.none
 
     else
-        Element.row [ spacing 4, centerX ]
-            (label :: badges)
+        Element.row [ spacing 8, centerX ]
+            (label :: teamCodes)
 
 
 viewTeamBadge : SelectionRound -> RoundSelections -> TeamData -> Team -> Element Msg
@@ -253,11 +281,17 @@ viewTeamBadge round selections teamData_ team =
         Element.el
             [ Element.Events.onClick (SelectTeam round team)
             , Element.pointer
+            , Font.color Color.primaryText
+            , UI.Font.mono
             ]
-            (UI.Button.teamBadgeVerySmall UI.Style.Potential team)
+            (Element.text (T.display team))
 
     else
-        UI.Button.teamBadgeVerySmall UI.Style.Irrelevant team
+        Element.el
+            [ Font.color Color.grey
+            , UI.Font.mono
+            ]
+            (Element.text (T.display team))
 
 
 viewPlacedBadge : Team -> Element Msg
@@ -265,7 +299,9 @@ viewPlacedBadge team =
     Element.el
         [ Element.Events.onClick (DeselectTeam team)
         , Element.pointer
+        , Font.color Color.green
+        , UI.Font.mono
         ]
-        (UI.Button.teamBadgeVerySmall UI.Style.Selected team)
+        (Element.text (T.display team))
 
 

--- a/src/Form/Card.elm
+++ b/src/Form/Card.elm
@@ -1,8 +1,9 @@
-module Form.Card exposing (findByCardId, getBracketCard, getGroupMatchesCard, update, updateBracketCard, updateGroupMatchesCard, updateScreenCard, updateScreenCards)
+module Form.Card exposing (findByCardId, getBracketCard, getGroupMatchesCard, getParticipantCard, update, updateBracketCard, updateGroupMatchesCard, updateParticipantCard, updateScreenCard, updateScreenCards)
 
 import Bets.Types exposing (Group(..), Round(..))
 import Form.Bracket.Types as Bracket
 import Form.GroupMatches.Types as GroupMatches
+import Form.Participant.Types as Participant
 import Types exposing (Card(..), Info(..))
 import UI.Screen as Screen
 
@@ -78,6 +79,35 @@ updateGroupMatchesCard cards newGroupMatchesState =
     in
     List.map updateCard_ cards
 
+
+
+getParticipantCard : List Card -> Maybe Participant.State
+getParticipantCard cards =
+    List.filterMap
+        (\c ->
+            case c of
+                ParticipantCard s ->
+                    Just s
+
+                _ ->
+                    Nothing
+        )
+        cards
+        |> List.head
+
+
+updateParticipantCard : List Card -> Participant.State -> List Card
+updateParticipantCard cards newState =
+    List.map
+        (\c ->
+            case c of
+                ParticipantCard _ ->
+                    ParticipantCard newState
+
+                _ ->
+                    c
+        )
+        cards
 
 
 -- findIDByAnswerId : Model Msg -> Maybe AnswerID -> Maybe Int

--- a/src/Form/Participant/Types.elm
+++ b/src/Form/Participant/Types.elm
@@ -1,8 +1,23 @@
-module Form.Participant.Types exposing (Attr(..), Msg(..))
+module Form.Participant.Types exposing (Attr(..), FieldTag(..), Msg(..), State)
+
+
+type alias State =
+    { activeField : Maybe FieldTag }
+
+
+type FieldTag
+    = NameTag
+    | PostalTag
+    | ResidenceTag
+    | EmailTag
+    | PhoneTag
+    | KnowsTag
 
 
 type Msg
     = Set Attr
+    | FocusField FieldTag
+    | BlurField
 
 
 type Attr

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -4,6 +4,8 @@ import Bets.Bet
 import Bets.Types exposing (Group(..))
 import Bets.Types.Group as Group
 import Element exposing (padding, paddingXY, px, spacing, width)
+import Element.Events
+import Element.Font as Font
 import Form.Bracket
 import Form.Bracket.Types as BracketTypes
 import Form.GroupMatches
@@ -13,6 +15,8 @@ import Form.Submit
 import Form.Topscorer
 import Types exposing (Card(..), Model, Msg(..))
 import UI.Button
+import UI.Color as Color
+import UI.Font
 import UI.Screen as Screen
 import UI.Style
 
@@ -71,8 +75,8 @@ viewCard model idx card =
         TopscorerCard ->
             Element.map TopscorerMsg (Form.Topscorer.view model.bet)
 
-        ParticipantCard ->
-            Element.map ParticipantMsg (Form.Participant.view model.bet)
+        ParticipantCard state ->
+            Element.map ParticipantMsg (Form.Participant.view state model.bet)
 
         SubmitCard ->
             let
@@ -105,7 +109,7 @@ sectionOf card =
         TopscorerCard ->
             TopscorerSection
 
-        ParticipantCard ->
+        ParticipantCard _ ->
             SubmitSection
 
         SubmitCard ->
@@ -173,8 +177,8 @@ groupSectionTargetIndex model =
             )
 
 
-viewTopPills : Model Msg -> Int -> Element.Element Msg
-viewTopPills model currentIdx =
+viewTopCheckboxes : Model Msg -> Int -> Element.Element Msg
+viewTopCheckboxes model currentIdx =
     let
         currentSection =
             List.drop currentIdx model.cards
@@ -182,38 +186,66 @@ viewTopPills model currentIdx =
                 |> Maybe.map sectionOf
                 |> Maybe.withDefault IntroSection
 
-        mkSemantics section complete =
+        indicator section complete =
             if section == currentSection then
-                UI.Style.PillB
+                "[.]"
 
             else if complete then
-                UI.Style.PillA
+                "[x]"
 
             else
-                UI.Style.Pill
+                "[ ]"
 
         bracketIdx =
-            findCardIndex (\c -> case c of
-                BracketCard _ -> True
-                _ -> False) model
+            findCardIndex
+                (\c ->
+                    case c of
+                        BracketCard _ ->
+                            True
+
+                        _ ->
+                            False
+                )
+                model
                 |> Maybe.withDefault 13
 
         topscorerIdx =
-            findCardIndex (\c -> case c of
-                TopscorerCard -> True
-                _ -> False) model
+            findCardIndex
+                (\c ->
+                    case c of
+                        TopscorerCard ->
+                            True
+
+                        _ ->
+                            False
+                )
+                model
                 |> Maybe.withDefault 14
 
         participantIdx =
-            findCardIndex (\c -> case c of
-                ParticipantCard -> True
-                _ -> False) model
+            findCardIndex
+                (\c ->
+                    case c of
+                        ParticipantCard _ ->
+                            True
+
+                        _ ->
+                            False
+                )
+                model
                 |> Maybe.withDefault 15
 
         submitIdx =
-            findCardIndex (\c -> case c of
-                SubmitCard -> True
-                _ -> False) model
+            findCardIndex
+                (\c ->
+                    case c of
+                        SubmitCard ->
+                            True
+
+                        _ ->
+                            False
+                )
+                model
                 |> Maybe.withDefault 16
 
         submitTarget =
@@ -222,18 +254,40 @@ viewTopPills model currentIdx =
 
             else
                 participantIdx
+
+        stepNum =
+            currentIdx + 1
+
+        totalSteps =
+            List.length model.cards
+
+        stepCounter =
+            "stap " ++ String.fromInt stepNum ++ "/" ++ String.fromInt totalSteps
+
+        clickableCheck ind msg label =
+            Element.el
+                [ Element.Events.onClick msg
+                , Element.pointer
+                , Font.color Color.orange
+                , UI.Font.mono
+                ]
+                (Element.text (ind ++ " " ++ label))
     in
-    Element.row [ Element.spacing 8, Element.centerX ]
-        [ UI.Button.pill (mkSemantics IntroSection True) (NavigateTo 0) "intro"
-        , UI.Button.pill (mkSemantics GroupSection (allGroupsComplete model)) (NavigateTo (groupSectionTargetIndex model)) "groepen"
-        , UI.Button.pill (mkSemantics BracketSection (Form.Bracket.isCompleteQualifiers model.bet)) (NavigateTo bracketIdx) "schema"
-        , UI.Button.pill (mkSemantics TopscorerSection (Form.Topscorer.isComplete model.bet)) (NavigateTo topscorerIdx) "topscorer"
-        , UI.Button.pill (mkSemantics SubmitSection False) (NavigateTo submitTarget) "inzenden"
+    Element.row [ Element.width Element.fill, Element.paddingXY 0 4 ]
+        [ Element.wrappedRow [ Element.spacing 16 ]
+            [ clickableCheck (indicator IntroSection True) (NavigateTo 0) "intro"
+            , clickableCheck (indicator GroupSection (allGroupsComplete model)) (NavigateTo (groupSectionTargetIndex model)) "groepen"
+            , clickableCheck (indicator BracketSection (Form.Bracket.isCompleteQualifiers model.bet)) (NavigateTo bracketIdx) "schema"
+            , clickableCheck (indicator TopscorerSection (Form.Topscorer.isComplete model.bet)) (NavigateTo topscorerIdx) "topscorer"
+            , clickableCheck (indicator SubmitSection False) (NavigateTo submitTarget) "inzenden"
+            ]
+        , Element.el [ Element.alignRight, Font.color Color.grey, UI.Font.mono ]
+            (Element.text stepCounter)
         ]
 
 
-viewGroupSubPills : Model Msg -> Int -> Element.Element Msg
-viewGroupSubPills model currentIdx =
+viewGroupSubIndicators : Model Msg -> Int -> Element.Element Msg
+viewGroupSubIndicators model currentIdx =
     let
         groupCardsWithIndex =
             List.indexedMap Tuple.pair model.cards
@@ -250,28 +304,47 @@ viewGroupSubPills model currentIdx =
         isInGroupSection =
             List.any (\( idx, _ ) -> idx == currentIdx) groupCardsWithIndex
 
-        viewSubPill ( cardIdx, card ) =
+        viewGroupLetter ( cardIdx, card ) =
             case card of
                 GroupMatchesCard state ->
                     let
-                        semantics =
-                            if cardIdx == currentIdx then
-                                UI.Style.PillB
+                        isActive =
+                            cardIdx == currentIdx
 
-                            else if Form.GroupMatches.isComplete state.group model.bet then
-                                UI.Style.PillA
+                        isComplete =
+                            Form.GroupMatches.isComplete state.group model.bet
+
+                        label =
+                            if isActive then
+                                Group.toString state.group ++ "*"
 
                             else
-                                UI.Style.Pill
+                                Group.toString state.group
+
+                        clr =
+                            if isActive then
+                                Color.orange
+
+                            else if isComplete then
+                                Color.green
+
+                            else
+                                Color.grey
                     in
-                    UI.Button.pill semantics (NavigateTo cardIdx) (Group.toString state.group)
+                    Element.el
+                        [ Element.Events.onClick (NavigateTo cardIdx)
+                        , Element.pointer
+                        , Font.color clr
+                        , UI.Font.mono
+                        ]
+                        (Element.text label)
 
                 _ ->
                     Element.none
     in
     if isInGroupSection then
-        Element.wrappedRow [ Element.spacing 4, Element.centerX ]
-            (List.map viewSubPill groupCardsWithIndex)
+        Element.wrappedRow [ Element.spacing 8 ]
+            (List.map viewGroupLetter groupCardsWithIndex)
 
     else
         Element.none
@@ -287,23 +360,19 @@ viewCardChrome model card i =
             Basics.max (i - 1) 0
 
         prevPill =
-            UI.Button.pill UI.Style.Focus (NavigateTo prev) "vorige"
+            UI.Button.pill UI.Style.Focus (NavigateTo prev) "< vorige"
 
         nextPill =
-            UI.Button.pill UI.Style.Focus (NavigateTo next) "volgende"
+            UI.Button.pill UI.Style.Focus (NavigateTo next) "volgende >"
 
         nav =
             Element.row [ Element.spacing 20, Element.centerX ] [ prevPill, nextPill ]
 
-        topPills =
-            viewTopPills model i
-
-        subPills =
-            viewGroupSubPills model i
-
-        pillsArea =
-            Element.column [ Element.spacing 4, Element.centerX ]
-                [ topPills, subPills ]
+        checkboxArea =
+            Element.column [ Element.spacing 4, Element.width Element.fill ]
+                [ viewTopCheckboxes model i
+                , viewGroupSubIndicators model i
+                ]
 
         isGroupCard =
             List.drop i model.cards
@@ -321,8 +390,8 @@ viewCardChrome model card i =
 
         groupNav =
             Element.row [ Element.spacing 20, Element.centerX ]
-                [ UI.Button.pillSmall UI.Style.Focus (NavigateTo prev) "vorige groep"
-                , UI.Button.pillSmall UI.Style.Focus (NavigateTo next) "volgende groep"
+                [ UI.Button.pillSmall UI.Style.Focus (NavigateTo prev) "< groep"
+                , UI.Button.pillSmall UI.Style.Focus (NavigateTo next) "groep >"
                 ]
 
         columnAttrs =
@@ -336,7 +405,7 @@ viewCardChrome model card i =
             ]
     in
     if isGroupCard then
-        Element.column columnAttrs [ pillsArea, card, groupNav ]
+        Element.column columnAttrs [ checkboxArea, card, groupNav ]
 
     else
-        Element.column columnAttrs [ pillsArea, nav, card ]
+        Element.column columnAttrs [ checkboxArea, nav, card ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -12,6 +12,7 @@ import Form.Card as Cards
 import Form.GroupMatches as GroupMatches
 import Form.Info
 import Form.Participant as Participant
+import Form.Participant.Types as ParticipantTypes
 import Form.Topscorer as Topscorer
 import Http
 import RemoteData exposing (RemoteData(..), WebData)
@@ -135,10 +136,27 @@ update msg model =
 
         ParticipantMsg act ->
             let
-                ( newBet, fx ) =
-                    Participant.update act model.bet
+                currentState =
+                    Cards.getParticipantCard model.cards
+                        |> Maybe.withDefault { activeField = Nothing }
+
+                ( newBet, newState, fx ) =
+                    Participant.update act currentState model.bet
+
+                newCards =
+                    Cards.updateParticipantCard model.cards newState
+
+                newBetState =
+                    case act of
+                        ParticipantTypes.Set _ ->
+                            Dirty
+
+                        _ ->
+                            model.betState
             in
-            ( { model | bet = newBet, betState = Dirty }, Cmd.map ParticipantMsg fx )
+            ( { model | bet = newBet, cards = newCards, betState = newBetState }
+            , Cmd.map ParticipantMsg fx
+            )
 
         InfoMsg act ->
             let

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -79,7 +79,7 @@ type Card
     | GroupMatchesCard GroupMatches.State
     | BracketCard Bracket.State
     | TopscorerCard
-    | ParticipantCard
+    | ParticipantCard Participant.State
     | SubmitCard
 
 
@@ -259,7 +259,7 @@ initCards sz =
         otherCards =
             [ BracketCard <| Bracket.init sz
             , TopscorerCard
-            , ParticipantCard
+            , ParticipantCard { activeField = Nothing }
             , SubmitCard
             ]
     in

--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -39,7 +39,7 @@ navlink semantics link linkText =
             Style.button semantics
                 [ paddingXY 15 5
                 , height (px 34)
-                , rounded 17
+                , rounded 0
                 , centerX
                 , centerY
                 ]

--- a/src/UI/Color.elm
+++ b/src/UI/Color.elm
@@ -21,6 +21,8 @@ module UI.Color exposing
     , secondaryText
     , selected
     , shadow
+    , terminalAccentDim
+    , terminalBorder
     , white
     , wrong
     )
@@ -63,32 +65,32 @@ red =
 
 black : Color
 black =
-    rgb255 40 20 30
+    rgb255 13 13 13
 
 
 dark_red : Color
 dark_red =
-    rgb255 100 0 0
+    rgb255 28 28 28
 
 
 dark_blue : Color
 dark_blue =
-    rgb255 0 0 100
+    rgb255 20 20 20
 
 
 light_blue : Color
 light_blue =
-    rgb255 77 135 255
+    rgb255 247 127 33
 
 
 grey : Color
 grey =
-    rgb255 90 90 90
+    rgb255 45 45 45
 
 
 shadow : Color
 shadow =
-    rgb255 50 50 80
+    rgb255 13 13 13
 
 
 potential : Color
@@ -134,17 +136,17 @@ selected =
 
 primary : Color
 primary =
-    rgb255 0x21 0x21 0x21
+    rgb255 18 18 18
 
 
 primaryDark : Color
 primaryDark =
-    rgb255 55 55 120
+    rgb255 35 35 35
 
 
 primaryLight : Color
 primaryLight =
-    rgb255 0x48 0x48 0x48
+    rgb255 60 60 60
 
 
 secondary : Color
@@ -179,4 +181,14 @@ secondaryText =
 
 panel : Color
 panel =
-    black
+    rgb255 22 22 22
+
+
+terminalBorder : Color
+terminalBorder =
+    rgb255 60 60 60
+
+
+terminalAccentDim : Color
+terminalAccentDim =
+    rgb255 180 90 15

--- a/src/UI/Style.elm
+++ b/src/UI/Style.elm
@@ -43,6 +43,7 @@ module UI.Style exposing
     , scoreColumn
     , scoreInput
     , scoreRow
+    , terminalInput
     , secondaryText
     , teamBadge
     , teamBadgeVerySmall
@@ -62,7 +63,7 @@ import Element.Font as Font
 import Html.Attributes
 import Svg exposing (font)
 import Svg.Attributes exposing (color, fontFamily, fontSize, y)
-import UI.Color as Color exposing (dark_blue, right, white)
+import UI.Color as Color exposing (dark_blue, right, terminalBorder, white)
 import UI.Font exposing (mono, scaled)
 import UI.Screen as Screen
 import Url.Parser exposing (top)
@@ -157,12 +158,13 @@ button semantics attrs =
 header1 : List (Element.Attribute msg) -> List (Element.Attribute msg)
 header1 attrs =
     attrs
-        ++ [ Background.color Color.primary
-           , Font.size (scaled 3)
-           , Font.color Color.primaryText
+        ++ [ Font.size (scaled 3)
+           , Font.color Color.orange
            , UI.Font.mono
            , Font.extraBold
            , Element.paddingXY 0 16
+           , Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
+           , Border.color Color.terminalBorder
            ]
 
 
@@ -171,19 +173,18 @@ header2 attrs =
     attrs
         ++ [ UI.Font.mono
            , Font.size (scaled 2)
-           , Font.color Color.secondaryText
+           , Font.color Color.orange
            , Element.paddingXY 0 10
            , Font.bold
+           , Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
+           , Border.color Color.terminalBorder
            ]
 
 
 body : List (Element.Attribute msg) -> List (Element.Attribute msg)
 body attrs =
     attrs
-        ++ [ Background.gradient
-                { angle = 90
-                , steps = [ Color.dark_blue, Color.black, Color.dark_red ]
-                }
+        ++ [ Background.color Color.black
            ]
 
 
@@ -254,7 +255,7 @@ normalBox attrs =
     attrs
         ++ [ padding 20
            , width fill
-           , Border.rounded 5
+           , Border.rounded 0
            ]
 
 
@@ -264,7 +265,9 @@ darkBox attrs =
         ++ [ padding 20
            , width fill
            , Background.color Color.primaryDark
-           , Border.rounded 18
+           , Border.rounded 0
+           , Border.width 1
+           , Border.color Color.terminalBorder
            ]
 
 
@@ -281,13 +284,13 @@ darkBox attrs =
 error : List (Element.Attribute msg) -> List (Element.Attribute msg)
 error attrs =
     attrs
-        ++ [ Background.color Color.secondaryLight
+        ++ [ Background.color Color.black
            , Border.width 1
            , Border.color Color.red
            , Font.color Color.red
            , Font.size (scaled 1)
            , Element.spacing 2
-           , UI.Font.lora
+           , UI.Font.mono
            ]
 
 
@@ -302,19 +305,14 @@ buttonActive =
     [ Background.color Color.light_blue
     , paddingXY 20 8
     , Font.size (scaled 2)
-    , Border.rounded 17
+    , Border.rounded 0
     , Font.color Color.primary
     , Border.width 1
+    , Border.color Color.light_blue
     , Element.pointer
     , Element.mouseOver
         [ Background.color Color.light_blue
-        , Font.color Color.primaryText
-        , Border.shadow
-            { offset = ( 0, 5 )
-            , blur = 10
-            , color = Color.shadow
-            , size = 1
-            }
+        , Font.color Color.primary
         ]
     , UI.Font.button
     , Element.centerY
@@ -327,9 +325,10 @@ buttonInactive =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 17
-    , Font.color Color.secondaryText
+    , Border.rounded 0
+    , Font.color Color.grey
     , Border.width 1
+    , Border.color Color.terminalBorder
     , Element.htmlAttribute <| Html.Attributes.style "cursor" "not-allowed"
     , UI.Font.button
     , Element.centerY
@@ -343,7 +342,7 @@ buttonWrong =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 17
+    , Border.rounded 0
     , Border.width 1
     , Element.pointer
     , UI.Font.button
@@ -358,7 +357,7 @@ buttonRight =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 17
+    , Border.rounded 0
     , Border.width 1
     , Element.pointer
     , UI.Font.button
@@ -373,8 +372,9 @@ buttonPerhaps =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 17
+    , Border.rounded 0
     , Border.width 1
+    , Border.color Color.terminalBorder
     , Element.pointer
     , UI.Font.button
     , Element.centerY
@@ -383,13 +383,13 @@ buttonPerhaps =
 
 buttonIrrelevant : List (Element.Attribute msg)
 buttonIrrelevant =
-    [ Border.color Color.panel
+    [ Border.color Color.terminalBorder
     , Border.width 1
     , Font.color Color.secondaryText
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 17
+    , Border.rounded 0
     , Element.pointer
     , UI.Font.button
     , Element.centerY
@@ -403,17 +403,13 @@ buttonPotential =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 17
+    , Border.rounded 0
+    , Border.width 1
+    , Border.color Color.terminalBorder
     , Element.pointer
     , Element.mouseOver
-        [ Background.color Color.grey
-        , Font.color Color.primaryText
-        , Border.shadow
-            { offset = ( 0, 5 )
-            , blur = 10
-            , color = Color.shadow
-            , size = 1
-            }
+        [ Background.color Color.primaryLight
+        , Font.color Color.orange
         ]
     , UI.Font.button
     , Element.centerY
@@ -423,13 +419,13 @@ buttonPotential =
 buttonSelected : List (Element.Attribute msg)
 buttonSelected =
     [ Background.color Color.panel
-    , Font.color Color.primaryText
+    , Font.color Color.orange
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 17
+    , Border.rounded 0
     , Border.width 1
-    , Border.color Color.right
+    , Border.color Color.orange
     , Element.pointer
     , UI.Font.button
     , Element.centerY
@@ -439,21 +435,16 @@ buttonSelected =
 buttonFocus : List (Element.Attribute msg)
 buttonFocus =
     [ Background.color Color.light_blue
-    , Font.color Color.dark_blue
+    , Font.color Color.primary
     , Border.width 1
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 17
+    , Border.rounded 0
     , Element.mouseOver
-        [ Border.shadow
-            { offset = ( 0, 5 )
-            , blur = 10
-            , color = Color.dark_blue
-            , size = -2
-            }
+        [ Font.color Color.primary
         ]
-    , Border.color Color.dark_blue
+    , Border.color Color.light_blue
     , Element.pointer
     , UI.Font.button
     , Element.centerY
@@ -462,21 +453,14 @@ buttonFocus =
 
 scoreButtonSBPotential : List (Element.Attribute msg)
 scoreButtonSBPotential =
-    [ Background.color Color.panel
-    , Border.rounded 6
-    , Font.size 16
-    , Font.color Color.primaryText
+    [ Background.color Color.black
+    , Border.rounded 0
     , Border.width 0
-    , Element.spacing 10
+    , Font.size 14
+    , Font.color Color.grey
     , Font.center
     , mouseOver
-        [ Background.color Color.grey
-        , Border.shadow
-            { offset = ( 0, 5 )
-            , blur = 10
-            , color = Color.black
-            , size = -2
-            }
+        [ Font.color Color.orange
         ]
     , Element.pointer
     , UI.Font.button
@@ -487,12 +471,12 @@ scoreButtonSBPotential =
 scoreButtonSBSelected : List (Element.Attribute msg)
 scoreButtonSBSelected =
     [ Background.color Color.orange
-    , Font.color Color.panel
+    , Font.color Color.primary
     , Font.size 15
     , paddingXY 15 5
     , Element.height (px 34)
     , Font.size (scaled 1)
-    , Border.rounded 17
+    , Border.rounded 0
     , Border.width 0
     , Element.spacing 10
     , Font.center
@@ -513,7 +497,7 @@ teamBadge semantics attrs =
                     Color.orange
 
                 _ ->
-                    Color.panel
+                    Color.terminalBorder
     in
     [ Background.color Color.panel
     , Font.color Color.primaryText
@@ -521,7 +505,7 @@ teamBadge semantics attrs =
     , Border.width 1
     , Element.spacing 10
     , Element.padding 10
-    , Border.rounded 5
+    , Border.rounded 0
     , Font.center
     , Font.size (scaled 1)
     , Element.pointer
@@ -544,7 +528,7 @@ teamBadgeVerySmall semantics attrs =
                     Color.orange
 
                 _ ->
-                    Color.panel
+                    Color.terminalBorder
     in
     [ Background.color Color.panel
     , Font.color Color.primaryText
@@ -552,7 +536,7 @@ teamBadgeVerySmall semantics attrs =
     , Border.width 1
     , Element.spacing 3
     , Element.padding 3
-    , Border.rounded 3
+    , Border.rounded 0
     , Font.center
     , Font.size 8
     , Element.pointer
@@ -567,10 +551,10 @@ teamButtonTBPotential =
     [ Background.color Color.panel
     , Font.color Color.primaryText
     , Border.width 1
-    , Border.color Color.panel
+    , Border.color Color.terminalBorder
     , Element.spacing 10
     , Element.padding 10
-    , Border.rounded 5
+    , Border.rounded 0
     , Font.center
     , Font.size (scaled 1)
     , Element.pointer
@@ -587,7 +571,7 @@ teamButtonTBSelected =
     , Border.color Color.right
     , Element.spacing 10
     , Element.padding 10
-    , Border.rounded 5
+    , Border.rounded 0
     , Font.center
     , Font.size (scaled 1)
     , Element.pointer
@@ -630,9 +614,35 @@ scoreColumn attrs =
 scoreInput : List (Element.Attribute msg) -> List (Element.Attribute msg)
 scoreInput attrs =
     attrs
-        ++ [ Border.width 2
-           , Border.color Color.secondaryLight
+        ++ [ Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
+           , Border.color Color.orange
+           , Background.color Color.black
+           , Font.color Color.orange
+           , Font.center
+           , Border.rounded 0
            , UI.Font.score
+           ]
+
+
+terminalInput : Bool -> List (Element.Attribute msg) -> List (Element.Attribute msg)
+terminalInput hasError attrs =
+    let
+        borderColor =
+            if hasError then
+                Color.red
+
+            else
+                Color.terminalBorder
+    in
+    attrs
+        ++ [ Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
+           , Border.color borderColor
+           , Border.rounded 0
+           , Background.color Color.black
+           , Font.color Color.white
+           , UI.Font.input
+           , Element.paddingXY 4 8
+           , Element.focused [ Border.color Color.orange ]
            ]
 
 
@@ -668,13 +678,13 @@ matchRow semantics attrs =
             , UI.Font.match
             , Border.color border
             , Border.width 1
-            , Border.rounded 10
+            , Border.rounded 0
             ]
 
         border =
             case semantics of
                 Active ->
-                    Color.white
+                    Color.orange
 
                 Right ->
                     Color.green
@@ -700,13 +710,13 @@ matchRowVerySmall semantics attrs =
             , UI.Font.match
             , Border.color border
             , Border.width 1
-            , Border.rounded 3
+            , Border.rounded 0
             ]
 
         border =
             case semantics of
                 Active ->
-                    Color.white
+                    Color.orange
 
                 Right ->
                     Color.green
@@ -724,15 +734,12 @@ kopje : List (Element.Attribute msg) -> List (Element.Attribute msg)
 kopje attrs =
     attrs
         ++ textBase
-            [ Font.color Color.white
-            , UI.Font.mono
-            , Font.extraBold
-            , Element.spacing 10
-            , Font.size 16
-            , Background.color Color.dark_red
-            , paddingXY 16 8
-            , Border.rounded 18
+            [ Font.color Color.orange
+            , Font.bold
             , Font.size (scaled 1)
+            , Border.widthEach { bottom = 0, top = 0, left = 2, right = 0 }
+            , Border.color Color.orange
+            , paddingEach { top = 0, bottom = 0, left = 8, right = 0 }
             ]
 
 
@@ -751,20 +758,15 @@ emphasis attrs =
 
 buttonPill : List (Element.Attribute msg)
 buttonPill =
-    [ Background.color Color.grey
+    [ Background.color Color.panel
     , Font.color Color.primaryText
-    , Border.rounded 5
+    , Border.rounded 0
+    , Border.width 1
+    , Border.color Color.terminalBorder
     , paddingXY 20 5
     , Element.pointer
     , Element.mouseOver
-        [ Background.color Color.light_blue
-        , Font.color Color.primaryText
-        , Border.shadow
-            { offset = ( 0, 5 )
-            , blur = 10
-            , color = Color.shadow
-            , size = 1
-            }
+        [ Font.color Color.orange
         ]
     , UI.Font.button
     , Element.centerY
@@ -773,23 +775,13 @@ buttonPill =
 
 buttonPillA : List (Element.Attribute msg)
 buttonPillA =
-    [ Background.color Color.light_blue
-    , Font.color Color.primaryText
-    , Border.rounded 5
-    , Border.color Color.white
+    [ Background.color Color.panel
+    , Font.color Color.orange
+    , Border.rounded 0
+    , Border.color Color.orange
     , paddingXY 20 5
     , Border.width 1
     , Element.pointer
-    , Element.mouseOver
-        [ Background.color Color.light_blue
-        , Font.color Color.primaryText
-        , Border.shadow
-            { offset = ( 0, 5 )
-            , blur = 10
-            , color = Color.shadow
-            , size = 1
-            }
-        ]
     , UI.Font.button
     , Element.centerY
     ]
@@ -797,22 +789,13 @@ buttonPillA =
 
 buttonPillB : List (Element.Attribute msg)
 buttonPillB =
-    [ Background.color Color.light_blue
-    , Font.color Color.primaryText
-    , Border.rounded 5
+    [ Background.color Color.orange
+    , Font.color Color.primary
+    , Border.rounded 0
     , paddingXY 20 5
-    , Border.color Color.light_blue
+    , Border.color Color.orange
+    , Border.width 1
     , Element.pointer
-    , Element.mouseOver
-        [ Background.color Color.light_blue
-        , Font.color Color.primaryText
-        , Border.shadow
-            { offset = ( 0, 5 )
-            , blur = 10
-            , color = Color.shadow
-            , size = 1
-            }
-        ]
     , UI.Font.button
     , Element.centerY
     ]
@@ -856,11 +839,11 @@ textInput hasError attrs =
                 Color.red
 
             else
-                Color.primaryDark
+                Color.terminalBorder
     in
     attrs
-        ++ [ Border.width 2
-           , Border.rounded 18
+        ++ [ Border.width 1
+           , Border.rounded 0
            , Border.color borderColor
            , Font.color Color.primaryDark
            , UI.Font.input

--- a/src/UI/Text.elm
+++ b/src/UI/Text.elm
@@ -8,6 +8,7 @@ module UI.Text exposing
     , simpleText
     , style
     , textSecondary
+    , timeText
     )
 
 import Element exposing (alignLeft, alignTop, spacing, width)
@@ -30,7 +31,8 @@ textSecondary txt =
 
 displayHeader : String -> Element.Element msg
 displayHeader txt =
-    Element.el (Style.header2 [ width Element.fill ]) (Element.text txt)
+    Element.el (Style.header2 [ width Element.fill ])
+        (Element.text ("--- " ++ String.toUpper txt ++ " ---"))
 
 
 simpleText : String -> Element.Element msg
@@ -159,3 +161,22 @@ dateText tz dt =
             dd ++ " " ++ String.fromInt d ++ " " ++ m ++ ", " ++ String.fromInt h ++ ":" ++ twoDigitString mn
     in
     dateString
+
+
+timeText : Time.Zone -> Time.Posix -> String
+timeText tz dt =
+    let
+        h =
+            Time.toHour tz dt
+
+        mn =
+            Time.toMinute tz dt
+
+        twoDigit n =
+            if n < 10 then
+                "0" ++ String.fromInt n
+
+            else
+                String.fromInt n
+    in
+    "[" ++ twoDigit h ++ ":" ++ twoDigit mn ++ "]"

--- a/src/View.elm
+++ b/src/View.elm
@@ -5,6 +5,8 @@ import Authentication
 import Bets.View
 import Browser
 import Element exposing (paddingXY, spacing)
+import Element.Background as Background
+import Element.Border as Border
 import Element.Font as Font exposing (Font)
 import Form.View
 import RemoteData exposing (RemoteData(..))
@@ -17,6 +19,7 @@ import Task
 import Types exposing (App(..), Card(..), Credentials(..), DataStatus(..), Flags, InputState(..), Model, Msg(..), Token(..))
 import UI.Button
 import UI.Color as Color
+import UI.Font
 import UI.Screen as Screen
 import UI.Style
 import Url
@@ -73,12 +76,22 @@ view model =
 
         link app =
             let
+                isActive =
+                    app == model.app
+
                 semantics =
-                    if app == model.app then
+                    if isActive then
                         UI.Style.Active
 
                     else
                         UI.Style.Potential
+
+                prefix =
+                    if isActive then
+                        "> "
+
+                    else
+                        "  "
 
                 ( linkUrl, linkText ) =
                     case app of
@@ -113,7 +126,7 @@ view model =
                             ( "#home", "home" )
             in
             -- Element.el [] wrapper for wrapperrow alignment misbehaviour
-            Element.el [] <| UI.Button.navlink semantics linkUrl linkText
+            Element.el [] <| UI.Button.navlink semantics linkUrl (prefix ++ linkText)
 
         linkList =
             case model.token of
@@ -124,12 +137,21 @@ view model =
                     [ Home, Ranking, Form ]
 
         links =
-            Element.wrappedRow [ Element.padding 12, Element.spacing 12 ]
-                (List.map link linkList)
+            Element.column
+                [ Element.width Element.fill ]
+                [ Element.wrappedRow [ Element.paddingXY 0 8, Element.spacing 4 ]
+                    (List.map link linkList)
+                , Element.el
+                    [ Element.width Element.fill
+                    , Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
+                    , Border.color Color.terminalBorder
+                    ]
+                    Element.none
+                ]
 
         page =
             Element.column
-                [ Element.padding 24
+                [ Element.paddingEach { top = 24, right = 24, bottom = 40, left = 24 }
                 , Element.spacing 24
                 , Element.centerX
                 ]
@@ -139,9 +161,110 @@ view model =
                 ]
 
         body =
-            Element.layout (UI.Style.body []) page
+            Element.layout
+                (UI.Style.body
+                    [ Element.inFront
+                        (Element.el
+                            [ Element.alignBottom, Element.width Element.fill ]
+                            (viewStatusBar model)
+                        )
+                    ]
+                )
+                page
     in
     { title = title, body = [ body ] }
+
+
+viewStatusBar : Model Msg -> Element.Element Msg
+viewStatusBar model =
+    let
+        currentCard =
+            List.drop model.idx model.cards
+                |> List.head
+
+        sectionLabel card =
+            case card of
+                Just (IntroCard _) ->
+                    "intro"
+
+                Just (GroupMatchesCard _) ->
+                    "groepen"
+
+                Just (BracketCard _) ->
+                    "schema"
+
+                Just TopscorerCard ->
+                    "topscorer"
+
+                Just (ParticipantCard _) ->
+                    "inzenden"
+
+                Just SubmitCard ->
+                    "inzenden"
+
+                Nothing ->
+                    ""
+
+        statusText =
+            case model.app of
+                Form ->
+                    let
+                        section =
+                            sectionLabel currentCard
+
+                        stepInfo =
+                            "stap "
+                                ++ String.fromInt (model.idx + 1)
+                                ++ "/"
+                                ++ String.fromInt (List.length model.cards)
+                    in
+                    "formulier > " ++ section ++ "  " ++ stepInfo
+
+                Home ->
+                    "home"
+
+                Ranking ->
+                    "stand"
+
+                RankingDetailsView ->
+                    "stand > detail"
+
+                Results ->
+                    "wedstrijden"
+
+                EditMatchResult ->
+                    "wedstrijden > bewerk"
+
+                KOResults ->
+                    "knockouts"
+
+                TSResults ->
+                    "topscorer"
+
+                Blog ->
+                    "blog"
+
+                Bets ->
+                    "inzendingen"
+
+                BetsDetailsView ->
+                    "inzending"
+
+                Login ->
+                    "login"
+    in
+    Element.row
+        [ Element.width Element.fill
+        , Element.paddingXY 12 6
+        , Background.color Color.black
+        , Border.widthEach { top = 1, bottom = 0, left = 0, right = 0 }
+        , Border.color Color.terminalBorder
+        ]
+        [ Element.el [ Font.color Color.grey, UI.Font.mono, Font.size (UI.Font.scaled 0) ]
+            (Element.text statusText)
+        , Element.el [ Element.alignRight, Font.color Color.grey, UI.Font.mono, Font.size (UI.Font.scaled 0) ]
+            (Element.text "v2026")
+        ]
 
 
 getApp : Url.Url -> ( App, Cmd Msg )
@@ -242,7 +365,15 @@ viewBlog model =
 viewVersion : Element.Element Msg
 viewVersion =
     Element.column
-        [ Font.color Color.black
+        [ Element.spacing 8
+        , Element.paddingXY 0 20
+        , Element.width Element.fill
+        , Border.widthEach { top = 1, bottom = 0, left = 0, right = 0 }
+        , Border.color Color.terminalBorder
         ]
-        [ Element.text "june 15 16:31"
+        [ Element.el [ Font.color Color.grey, UI.Font.mono, Font.size (UI.Font.scaled 0) ]
+            (Element.text "v2026")
+        , Element.link
+            [ Font.color Color.orange, UI.Font.mono, Font.size (UI.Font.scaled 0) ]
+            { url = "https://claude.ai/code", label = Element.text "Built with Claude Code" }
         ]

--- a/src/index.html
+++ b/src/index.html
@@ -10,20 +10,15 @@
 
     <script type="text/javascript" src="main.js"></script>
 
-    <link
-      href="https://fonts.leapis.com/css?family=Lora|Asap|Special+Egooglite|Roboto+Slab:200|Roboto+Mono"
-      rel="stylesheet"
-    />
-
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Oxygen+Mono&family=Sometype+Mono:ital,wght@0,400..700;1,400..700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Sometype+Mono:ital,wght@0,400..700;1,400..700&display=swap"
       rel="stylesheet"
     />
   </head>
 
-  <body></body>
+  <body style="background-color: #0d0d0d; margin: 0; padding: 0;"></body>
 
   <script type="text/javascript">
     var app = Elm.Main.init({


### PR DESCRIPTION
- Replace pill navigation with terminal-style checkboxes ([x]/[.]/[ ]) and stap N/M step counter in Form/View
- Add viewStatusBar (inFront+alignBottom overlay) and terminal-style global nav with > prefix for active item in View.elm
- Group sub-nav: viewGroupSubIndicators with A* (active) colored letters
- Bracket stepper: ASCII pipeline with label+dot columns and --- connectors; T.display text codes replace flag badges
- Participant/Types: add State with activeField focus tracking
- Form/Card: handle ParticipantCard with Participant.State
- Activities: [HH:MM] log-line format for comments and blog posts
- UI/Style: terminal-aesthetic score input (underline-only, dark bg); terminalInput style with orange focused border
- UI/Color, UI/Text, UI/Button: extend palette and text helpers for terminal aesthetic (displayHeader, timeText, mono font)
- index.html: dark background base styles