### PR TITLE
Improve GroupMatches UI: scroll wheel (#91)

### DIFF
--- a/src/Form/Card.elm
+++ b/src/Form/Card.elm
@@ -1,6 +1,6 @@
 module Form.Card exposing (findByCardId, getBracketCard, getGroupMatchesCard, getParticipantCard, update, updateBracketCard, updateGroupMatchesCard, updateParticipantCard, updateScreenCard, updateScreenCards)
 
-import Bets.Types exposing (Group(..), Round(..))
+import Bets.Types exposing (Round(..))
 import Form.Bracket.Types as Bracket
 import Form.GroupMatches.Types as GroupMatches
 import Form.Participant.Types as Participant
@@ -43,22 +43,18 @@ updateBracketCard cards newBracketState =
     List.map updateCard_ cards
 
 
-getGroupMatchesCard : List Card -> Group -> Maybe Card
-getGroupMatchesCard cards grp =
+getGroupMatchesCard : List Card -> Maybe Card
+getGroupMatchesCard cards =
     let
-        updateCard_ card =
+        getCard_ card =
             case card of
-                GroupMatchesCard groupMatchesState ->
-                    if groupMatchesState.group == grp then
-                        Just card
-
-                    else
-                        Nothing
+                GroupMatchesCard _ ->
+                    Just card
 
                 _ ->
                     Nothing
     in
-    List.filterMap updateCard_ cards
+    List.filterMap getCard_ cards
         |> List.head
 
 
@@ -67,12 +63,8 @@ updateGroupMatchesCard cards newGroupMatchesState =
     let
         updateCard_ card =
             case card of
-                GroupMatchesCard groupMatchesState ->
-                    if groupMatchesState.group == newGroupMatchesState.group then
-                        GroupMatchesCard newGroupMatchesState
-
-                    else
-                        card
+                GroupMatchesCard _ ->
+                    GroupMatchesCard newGroupMatchesState
 
                 _ ->
                     card

--- a/src/Form/GroupMatches.elm
+++ b/src/Form/GroupMatches.elm
@@ -1,97 +1,426 @@
 module Form.GroupMatches exposing (isComplete, update, view)
 
 import Bets.Bet exposing (setMatchScore)
-import Bets.Types exposing (Answer(..), AnswerGroupMatch, Bet, Group, GroupMatch(..), MatchID, Score, Team)
+import Bets.Types exposing (Answer(..), AnswerGroupMatch, Bet, Group(..), GroupMatch(..), MatchID, Score, Team)
 import Bets.Types.Answer.GroupMatches as GroupMatches
 import Bets.Types.Group as G
 import Bets.Types.Match as M
 import Bets.Types.Score as S
 import Bets.Types.Team as T
-import Element exposing (centerX, centerY, fill, height, padding, paddingXY, px, spacing, width)
+import Element exposing (centerX, centerY, fill, padding, paddingXY, px, spacing, width)
 import Element.Border as Border
 import Element.Events
 import Element.Font as Font
 import Element.Input as Input
 import Form.GroupMatches.Types exposing (ChangeCursor(..), Msg(..), State, updateCursor)
-import List.Extra exposing (groupsOf)
-import UI.Button.Score exposing (displayScore)
+import Html.Events
+import Json.Decode
+import List.Extra
+import UI.Button.Score
 import UI.Color as Color
 import UI.Font
-import UI.Match
 import UI.Page exposing (page)
 import UI.Style
-import UI.Team
 import UI.Text
 
 
-isComplete : Group -> Bet -> Bool
-isComplete grp bet =
-    GroupMatches.isCompleteGroup grp bet.answers.matches
+isComplete : Bet -> Bool
+isComplete bet =
+    GroupMatches.isComplete bet.answers.matches
 
 
 update : Msg -> State -> Bet -> ( Bet, State, Cmd Msg )
 update action state bet =
+    let
+        allMatchIDs =
+            List.map Tuple.first bet.answers.matches
+    in
     case action of
         UpdateHome matchID h ->
-            ( setMatchScore bet matchID ( Just h, Nothing ), updateCursor state bet Dont, Cmd.none )
+            ( setMatchScore bet matchID ( Just h, Nothing ), updateCursor state allMatchIDs Dont, Cmd.none )
 
         UpdateAway matchID a ->
-            ( setMatchScore bet matchID ( Nothing, Just a ), updateCursor state bet Implicit, Cmd.none )
+            ( setMatchScore bet matchID ( Nothing, Just a ), updateCursor state allMatchIDs Implicit, Cmd.none )
 
         Update matchID h a ->
-            ( setMatchScore bet matchID ( Just h, Just a ), updateCursor state bet Implicit, Cmd.none )
+            ( setMatchScore bet matchID ( Just h, Just a ), updateCursor state allMatchIDs Implicit, Cmd.none )
 
         SelectMatch matchID ->
-            ( bet, updateCursor state bet (Explicit matchID), Cmd.none )
+            ( bet, updateCursor state allMatchIDs (Explicit matchID), Cmd.none )
+
+        ScrollDown ->
+            ( bet, updateCursor state allMatchIDs Implicit, Cmd.none )
+
+        ScrollUp ->
+            let
+                newCursor =
+                    allMatchIDs
+                        |> List.Extra.takeWhile (\mId -> mId /= state.cursor)
+                        |> List.Extra.last
+                        |> Maybe.withDefault state.cursor
+            in
+            ( bet, { state | cursor = newCursor }, Cmd.none )
+
+        JumpToGroup grp ->
+            let
+                groupMatches =
+                    GroupMatches.findGroupMatchAnswers grp bet.answers.matches
+
+                firstIncomplete =
+                    groupMatches
+                        |> List.filter (\( _, agm ) -> not (isAnswerGroupMatchComplete agm))
+                        |> List.head
+                        |> Maybe.map Tuple.first
+
+                firstMatch =
+                    groupMatches
+                        |> List.head
+                        |> Maybe.map Tuple.first
+
+                newCursor =
+                    firstIncomplete
+                        |> Maybe.withDefault (Maybe.withDefault state.cursor firstMatch)
+            in
+            ( bet, { state | cursor = newCursor }, Cmd.none )
+
+        TouchStart y ->
+            ( bet, { state | touchStartY = Just y }, Cmd.none )
+
+        TouchEnd y ->
+            let
+                newState =
+                    case state.touchStartY of
+                        Just startY ->
+                            let
+                                delta =
+                                    startY - y
+                            in
+                            if delta > 30 then
+                                updateCursor { state | touchStartY = Nothing } allMatchIDs Implicit
+
+                            else if delta < -30 then
+                                let
+                                    newCursor =
+                                        allMatchIDs
+                                            |> List.Extra.takeWhile (\mId -> mId /= state.cursor)
+                                            |> List.Extra.last
+                                            |> Maybe.withDefault state.cursor
+                                in
+                                { state | cursor = newCursor, touchStartY = Nothing }
+
+                            else
+                                { state | touchStartY = Nothing }
+
+                        Nothing ->
+                            state
+            in
+            ( bet, newState, Cmd.none )
 
         NoOp ->
             ( bet, state, Cmd.none )
 
 
+isAnswerGroupMatchComplete : AnswerGroupMatch -> Bool
+isAnswerGroupMatchComplete (Answer (GroupMatch _ _ mScore) _) =
+    case mScore of
+        Just ( Just _, Just _ ) ->
+            True
+
+        _ ->
+            False
+
+
+groupOfMatch : ( MatchID, AnswerGroupMatch ) -> Group
+groupOfMatch ( _, Answer (GroupMatch grp _ _) _ ) =
+    grp
+
+
 view : Bet -> State -> Element.Element Msg
 view bet state =
     let
-        groupMatches =
-            GroupMatches.findGroupMatchAnswers state.group bet.answers.matches
+        allMatches =
+            bet.answers.matches
 
         mCurrentMatch =
-            let
-                isCurrentMatch matchID ( mId, _ ) =
-                    matchID == mId
-            in
-            List.filter (isCurrentMatch state.cursor) groupMatches
+            List.filter (\( mId, _ ) -> mId == state.cursor) allMatches
                 |> List.head
     in
-    view_ state mCurrentMatch groupMatches
+    page "groupmatch"
+        [ UI.Text.displayHeader "Wedstrijden"
+        , viewGroupNav bet state
+        , viewScrollWheel bet state
+        , case mCurrentMatch of
+            Just ( matchID, Answer (GroupMatch _ match mScore) _ ) ->
+                Element.column [ centerX, spacing 8 ]
+                    [ viewInput state matchID (M.homeTeam match) (M.awayTeam match) mScore
+                    , viewKeyboard matchID
+                    ]
 
-
-view_ : State -> Maybe ( MatchID, AnswerGroupMatch ) -> List ( MatchID, AnswerGroupMatch ) -> Element.Element Msg
-view_ state mMatch matches =
-    case mMatch of
-        Just ( matchID, Answer (GroupMatch g match mScore) _ ) ->
-            page "groupmatch"
-                [ displayHeader g
-                , introduction
-                , displayMatches3x1 state.cursor matches
-                , viewInput state matchID (M.homeTeam match) (M.awayTeam match) mScore
-                , viewKeyboard matchID
-                ]
-
-        _ ->
-            Element.none
-
-
-displayHeader : Group -> Element.Element Msg
-displayHeader grp =
-    UI.Text.displayHeader ("Wedstrijden groep " ++ G.toString grp)
-
-
-introduction : Element.Element Msg
-introduction =
-    Element.paragraph []
-        [ UI.Text.simpleText "Voorspel de uitslagen door op de knop met de gewenste score te klikken. Voor een juiste uitslag krijg je 3 punten. Heb je enkel de toto goed levert je dat 1 punt op."
-        , UI.Text.simpleText "We gaan niet alle wedstrijden voorspellen; daarvoor zijn het er teveel dit WK. We hebben per poule 3 wedstrijden geselecteerd die je mag voorspellen."
+            _ ->
+                Element.none
+        , viewProgress bet
         ]
+
+
+
+-- Scroll Wheel
+
+
+type ScrollItem
+    = MatchRow ( MatchID, AnswerGroupMatch )
+    | GroupBoundary Group
+
+
+buildScrollItems : List ( MatchID, AnswerGroupMatch ) -> List ScrollItem
+buildScrollItems matches =
+    let
+        go prevGroup remaining acc =
+            case remaining of
+                [] ->
+                    List.reverse acc
+
+                item :: rest ->
+                    let
+                        grp =
+                            groupOfMatch item
+                    in
+                    if Just grp /= prevGroup then
+                        go (Just grp) rest (MatchRow item :: GroupBoundary grp :: acc)
+
+                    else
+                        go (Just grp) rest (MatchRow item :: acc)
+    in
+    go Nothing matches []
+
+
+viewScrollWheel : Bet -> State -> Element.Element Msg
+viewScrollWheel bet state =
+    let
+        allMatches =
+            bet.answers.matches
+
+        allMatchIDs =
+            List.map Tuple.first allMatches
+
+        cursorIdx =
+            List.Extra.findIndex (\mId -> mId == state.cursor) allMatchIDs
+                |> Maybe.withDefault 0
+
+        total =
+            List.length allMatches
+
+        startIdx =
+            max 0 (cursorIdx - 2)
+
+        endIdx =
+            min (total - 1) (cursorIdx + 2)
+
+        visibleMatches =
+            List.indexedMap Tuple.pair allMatches
+                |> List.filterMap
+                    (\( i, m ) ->
+                        if i >= startIdx && i <= endIdx then
+                            Just m
+
+                        else
+                            Nothing
+                    )
+
+        scrollItems =
+            buildScrollItems visibleMatches
+
+        touchStartAttr =
+            Element.htmlAttribute
+                (Html.Events.on "touchstart"
+                    (Json.Decode.map TouchStart
+                        (Json.Decode.at [ "touches", "0", "clientY" ] Json.Decode.float)
+                    )
+                )
+
+        touchEndAttr =
+            Element.htmlAttribute
+                (Html.Events.preventDefaultOn "touchend"
+                    (Json.Decode.map (\y -> ( TouchEnd y, True ))
+                        (Json.Decode.at [ "changedTouches", "0", "clientY" ] Json.Decode.float)
+                    )
+                )
+    in
+    Element.column
+        [ centerX, spacing 2, touchStartAttr, touchEndAttr ]
+        (List.map (viewScrollItem state.cursor) scrollItems)
+
+
+viewScrollItem : MatchID -> ScrollItem -> Element.Element Msg
+viewScrollItem cursor item =
+    case item of
+        MatchRow matchData ->
+            viewScrollLine cursor matchData
+
+        GroupBoundary grp ->
+            Element.el
+                [ centerX, Font.color Color.grey, UI.Font.mono ]
+                (Element.text ("-- " ++ G.toString grp ++ " --"))
+
+
+viewScrollLine : MatchID -> ( MatchID, AnswerGroupMatch ) -> Element.Element Msg
+viewScrollLine cursor ( answerId, Answer (GroupMatch _ match mScore) _ ) =
+    let
+        home =
+            String.padRight 4 ' ' (M.homeTeam match |> T.display)
+
+        away =
+            String.padRight 4 ' ' (M.awayTeam match |> T.display)
+
+        h =
+            mScore |> Maybe.andThen S.homeScore |> Maybe.map String.fromInt |> Maybe.withDefault "_"
+
+        a =
+            mScore |> Maybe.andThen S.awayScore |> Maybe.map String.fromInt |> Maybe.withDefault "_"
+
+        scoreStr =
+            h ++ "-" ++ a
+
+        isActive =
+            cursor == answerId
+
+        isCompleted =
+            case mScore of
+                Just ( Just _, Just _ ) ->
+                    True
+
+                _ ->
+                    False
+
+        textColor =
+            if isActive || isCompleted then
+                Color.white
+
+            else
+                Color.grey
+
+        scoreColor =
+            if isCompleted then
+                Color.green
+
+            else if isActive then
+                Color.orange
+
+            else
+                Color.grey
+
+        prefixStr =
+            if isActive then
+                "  >  "
+
+            else
+                "     "
+
+        prefixColor =
+            if isActive then
+                Color.orange
+
+            else
+                Color.grey
+
+        suffixEl =
+            if isActive then
+                Element.el [ Font.color Color.orange, UI.Font.mono ] (Element.text "  <")
+
+            else
+                Element.none
+
+        mkEl clr str =
+            Element.el [ Font.color clr, UI.Font.mono ] (Element.text str)
+    in
+    Element.el
+        [ Element.Events.onClick (SelectMatch answerId)
+        , Element.pointer
+        ]
+        (Element.row [ spacing 0 ]
+            [ mkEl prefixColor prefixStr
+            , mkEl textColor home
+            , mkEl Color.grey "  "
+            , mkEl scoreColor scoreStr
+            , mkEl Color.grey "  "
+            , mkEl textColor away
+            , suffixEl
+            ]
+        )
+
+
+
+-- Group Nav
+
+
+viewGroupNav : Bet -> State -> Element.Element Msg
+viewGroupNav bet state =
+    let
+        allGroups =
+            [ A, B, C, D, E, F, G, H, I, J, K, L ]
+
+        currentGroup =
+            bet.answers.matches
+                |> List.filter (\( mId, _ ) -> mId == state.cursor)
+                |> List.head
+                |> Maybe.map groupOfMatch
+
+        viewGroupLetter grp =
+            let
+                isActive =
+                    Just grp == currentGroup
+
+                grpComplete =
+                    GroupMatches.isCompleteGroup grp bet.answers.matches
+
+                label =
+                    if isActive then
+                        G.toString grp ++ "*"
+
+                    else
+                        G.toString grp
+
+                clr =
+                    if isActive then
+                        Color.orange
+
+                    else if grpComplete then
+                        Color.green
+
+                    else
+                        Color.grey
+            in
+            Element.el
+                [ Element.Events.onClick (JumpToGroup grp)
+                , Element.pointer
+                , Font.color clr
+                , UI.Font.mono
+                ]
+                (Element.text label)
+    in
+    Element.wrappedRow [ centerX, spacing 8 ]
+        (List.map viewGroupLetter allGroups)
+
+
+
+-- Progress
+
+
+viewProgress : Bet -> Element.Element Msg
+viewProgress bet =
+    let
+        total =
+            List.length bet.answers.matches
+
+        completed =
+            List.filter (\( _, agm ) -> isAnswerGroupMatchComplete agm) bet.answers.matches
+                |> List.length
+    in
+    Element.el [ centerX, Font.color Color.grey, UI.Font.mono ]
+        (Element.text (String.fromInt completed ++ "/" ++ String.fromInt total))
+
+
+
+-- Score Input
 
 
 viewInput :
@@ -157,143 +486,6 @@ viewInput _ matchID homeTeam awayTeam mScore =
         ]
 
 
-displayMatches3x1 : MatchID -> List ( MatchID, AnswerGroupMatch ) -> Element.Element Msg
-displayMatches3x1 cursor matches =
-    Element.column [ centerX, centerY, spacing 4 ]
-        (List.map (viewMatchLine cursor) matches)
-
-
-viewMatchLine : MatchID -> ( MatchID, AnswerGroupMatch ) -> Element.Element Msg
-viewMatchLine cursor ( answerId, Answer (GroupMatch _ match mScore) _ ) =
-    let
-        home =
-            M.homeTeam match |> T.display
-
-        away =
-            M.awayTeam match |> T.display
-
-        h =
-            mScore |> Maybe.andThen S.homeScore |> Maybe.map String.fromInt |> Maybe.withDefault "_"
-
-        a =
-            mScore |> Maybe.andThen S.awayScore |> Maybe.map String.fromInt |> Maybe.withDefault "_"
-
-        scoreStr =
-            h ++ "-" ++ a
-
-        cursorStr =
-            if cursor == answerId then
-                "  <"
-
-            else
-                ""
-
-        line =
-            String.padRight 4 ' ' home
-                ++ scoreStr
-                ++ "  "
-                ++ String.padRight 4 ' ' away
-                ++ cursorStr
-    in
-    Element.el
-        [ Element.Events.onClick (SelectMatch answerId)
-        , Element.pointer
-        , Font.color
-            (if cursor == answerId then
-                Color.orange
-
-             else
-                Color.white
-            )
-        , UI.Font.mono
-        ]
-        (Element.text line)
-
-
-displayMatches3x2 : MatchID -> List ( MatchID, AnswerGroupMatch ) -> Element.Element Msg
-displayMatches3x2 cursor matches =
-    let
-        display =
-            displayMatchHalfRow cursor
-
-        rows =
-            groupsOf 2 matches
-
-        row matches_ =
-            Element.row (UI.Style.matches [ spacing 20 ]) (List.filterMap display matches_)
-    in
-    --
-    Element.column [ centerX, spacing 20 ] (List.map row rows)
-
-
-displayMatchHalfRow : MatchID -> ( MatchID, AnswerGroupMatch ) -> Maybe (Element.Element Msg)
-displayMatchHalfRow cursor ( answerId, Answer (GroupMatch _ match mScore) _ ) =
-    let
-        semantics =
-            if cursor == answerId then
-                UI.Style.Active
-
-            else
-                UI.Style.Potential
-
-        disp =
-            let
-                handler =
-                    Element.Events.onClick (SelectMatch answerId)
-            in
-            UI.Match.display match mScore handler semantics
-    in
-    Just <| disp
-
-
-displayMatchFullRow : MatchID -> ( MatchID, AnswerGroupMatch ) -> Maybe (Element.Element Msg)
-displayMatchFullRow cursor ( answerId, Answer (GroupMatch _ match mScore) _ ) =
-    let
-        semantics =
-            if cursor == answerId then
-                UI.Style.Active
-
-            else
-                UI.Style.Potential
-
-        disp =
-            let
-                handler =
-                    Element.Events.onClick (SelectMatch answerId)
-            in
-            UI.Match.displayFullRow match mScore handler semantics
-    in
-    Just <| disp
-
-
-
--- scoreButton : UI.Style.ButtonSemantics -> MatchID -> ScoreButtonX -> Element.Element Msg
--- scoreButton c matchID sb =
---     let
---         ( msg, txt ) =
---             case sb of
---                 ZB _ ->
---                     ( NoOp, "" )
---                 SB _ ( home, away ) t ->
---                     ( Update matchID home away, t )
---     in
---     UI.Button.scoreButton c msg txt
-
-
 viewKeyboard : MatchID -> Element.Element Msg
 viewKeyboard matchId =
     UI.Button.Score.viewKeyboard NoOp (Update matchId)
-
-
-
--- viewKeyboard : MatchID -> Element.Element Msg
--- viewKeyboard matchID =
---     let
---         toButton s =
---             scoreButton UI.Style.Potential matchID s
---         toRow scoreList =
---             Element.row (UI.Style.scoreRow [ centerX, spacing 2, centerY ])
---                 (List.map toButton scoreList)
---     in
---     Element.column (UI.Style.scoreColumn [ centerX, spacing 2 ])
---         (List.map toRow UI.Button.Score.scores)

--- a/src/Form/GroupMatches/Types.elm
+++ b/src/Form/GroupMatches/Types.elm
@@ -2,23 +2,12 @@ module Form.GroupMatches.Types exposing
     ( ChangeCursor(..)
     , Msg(..)
     , State
-    , display
-    , findMatches
     , init
-    , isComplete
-    , matchScoreQuestions
     , updateCursor
     )
 
-import Bets.Bet exposing (findGroupMatchAnswers)
-import Bets.Types exposing (AnswerGroupMatches, Bet, Group(..), MatchID)
-import Bets.Types.Answer.GroupMatches as GroupMatches
-import Bets.Types.Group as Group
+import Bets.Types exposing (Group, MatchID)
 import List.Extra exposing (dropWhile)
-
-
-
--- type alias QuestionSetAnswers = Array MatchID
 
 
 type Msg
@@ -26,23 +15,24 @@ type Msg
     | UpdateAway MatchID Int
     | Update MatchID Int Int
     | SelectMatch MatchID
+    | ScrollUp
+    | ScrollDown
+    | JumpToGroup Group
+    | TouchStart Float
+    | TouchEnd Float
     | NoOp
 
 
 type alias State =
-    { group : Group
-    , prev : Maybe MatchID
-    , cursor : MatchID
-    , next : Maybe MatchID
+    { cursor : MatchID
+    , touchStartY : Maybe Float
     }
 
 
-init : Group -> MatchID -> State
-init group cursor =
-    { group = group
-    , prev = Nothing
-    , cursor = cursor
-    , next = Nothing
+init : MatchID -> State
+init cursor =
+    { cursor = cursor
+    , touchStartY = Nothing
     }
 
 
@@ -50,16 +40,6 @@ type ChangeCursor
     = Explicit MatchID
     | Implicit
     | Dont
-
-
-matchScoreQuestions : Group -> MatchID -> State
-matchScoreQuestions grp cursor =
-    init grp cursor
-
-
-findMatches : Group -> Bet -> AnswerGroupMatches
-findMatches grp bet =
-    findGroupMatchAnswers grp bet
 
 
 nextMatch : MatchID -> List MatchID -> MatchID
@@ -75,48 +55,18 @@ nextMatch matchID matches =
     Maybe.withDefault matchID (findNext |> Maybe.andThen List.head)
 
 
-updateCursor : State -> Bet -> ChangeCursor -> State
-updateCursor model bet changeCursor =
+updateCursor : State -> List MatchID -> ChangeCursor -> State
+updateCursor model allMatchIDs changeCursor =
     let
-        nxtMatch matches_ =
+        newCursor =
             case changeCursor of
                 Implicit ->
-                    nextMatch model.cursor matches_
+                    nextMatch model.cursor allMatchIDs
 
                 Explicit newCur ->
                     newCur
 
                 Dont ->
                     model.cursor
-
-        matches =
-            findMatches model.group bet
-                |> List.map Tuple.first
-
-        newCursor =
-            nxtMatch matches
-
-        prev =
-            Just model.cursor
     in
-    { model | cursor = newCursor, prev = prev }
-
-
-isComplete : Bet -> State -> Bool
-isComplete bet model =
-    findMatches model.group bet
-        |> GroupMatches.isComplete
-
-
-display : State -> String
-display model =
-    let
-        groupString =
-            Group.toString model.group
-    in
-    case model.group of
-        A ->
-            "Scores " ++ groupString
-
-        _ ->
-            groupString
+    { model | cursor = newCursor }

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -1,9 +1,7 @@
 module Form.View exposing (view)
 
 import Bets.Bet
-import Bets.Types exposing (Group(..))
-import Bets.Types.Group as Group
-import Element exposing (padding, paddingXY, px, spacing, width)
+import Element exposing (padding, spacing)
 import Element.Events
 import Element.Font as Font
 import Form.Bracket
@@ -55,7 +53,7 @@ viewCard model idx card =
             Element.map InfoMsg (Form.Info.view intro)
 
         GroupMatchesCard groupMatchesState ->
-            Element.map (GroupMatchMsg groupMatchesState.group) (Form.GroupMatches.view model.bet groupMatchesState)
+            Element.map GroupMatchMsg (Form.GroupMatches.view model.bet groupMatchesState)
 
         BracketCard bracketState ->
             let
@@ -126,55 +124,22 @@ findCardIndex pred model =
 
 allGroupsComplete : Model Msg -> Bool
 allGroupsComplete model =
-    model.cards
-        |> List.filterMap
-            (\card ->
-                case card of
-                    GroupMatchesCard state ->
-                        Just state.group
-
-                    _ ->
-                        Nothing
-            )
-        |> List.all (\grp -> Form.GroupMatches.isComplete grp model.bet)
+    Form.GroupMatches.isComplete model.bet
 
 
 groupSectionTargetIndex : Model Msg -> Int
 groupSectionTargetIndex model =
-    let
-        groupCardsWithIndex =
-            List.indexedMap Tuple.pair model.cards
-                |> List.filter
-                    (\( _, c ) ->
-                        case c of
-                            GroupMatchesCard _ ->
-                                True
+    findCardIndex
+        (\c ->
+            case c of
+                GroupMatchesCard _ ->
+                    True
 
-                            _ ->
-                                False
-                    )
-
-        firstIncomplete =
-            groupCardsWithIndex
-                |> List.filter
-                    (\( _, c ) ->
-                        case c of
-                            GroupMatchesCard state ->
-                                not (Form.GroupMatches.isComplete state.group model.bet)
-
-                            _ ->
-                                False
-                    )
-                |> List.head
-                |> Maybe.map Tuple.first
-    in
-    firstIncomplete
-        |> Maybe.withDefault
-            (groupCardsWithIndex
-                |> List.head
-                |> Maybe.map Tuple.first
-                |> Maybe.withDefault 1
-            )
+                _ ->
+                    False
+        )
+        model
+        |> Maybe.withDefault 1
 
 
 viewTopCheckboxes : Model Msg -> Int -> Element.Element Msg
@@ -207,7 +172,7 @@ viewTopCheckboxes model currentIdx =
                             False
                 )
                 model
-                |> Maybe.withDefault 13
+                |> Maybe.withDefault 2
 
         topscorerIdx =
             findCardIndex
@@ -220,7 +185,7 @@ viewTopCheckboxes model currentIdx =
                             False
                 )
                 model
-                |> Maybe.withDefault 14
+                |> Maybe.withDefault 3
 
         participantIdx =
             findCardIndex
@@ -233,7 +198,7 @@ viewTopCheckboxes model currentIdx =
                             False
                 )
                 model
-                |> Maybe.withDefault 15
+                |> Maybe.withDefault 4
 
         submitIdx =
             findCardIndex
@@ -246,7 +211,7 @@ viewTopCheckboxes model currentIdx =
                             False
                 )
                 model
-                |> Maybe.withDefault 16
+                |> Maybe.withDefault 5
 
         submitTarget =
             if Form.Participant.isComplete model.bet then
@@ -286,69 +251,6 @@ viewTopCheckboxes model currentIdx =
         ]
 
 
-viewGroupSubIndicators : Model Msg -> Int -> Element.Element Msg
-viewGroupSubIndicators model currentIdx =
-    let
-        groupCardsWithIndex =
-            List.indexedMap Tuple.pair model.cards
-                |> List.filter
-                    (\( _, c ) ->
-                        case c of
-                            GroupMatchesCard _ ->
-                                True
-
-                            _ ->
-                                False
-                    )
-
-        isInGroupSection =
-            List.any (\( idx, _ ) -> idx == currentIdx) groupCardsWithIndex
-
-        viewGroupLetter ( cardIdx, card ) =
-            case card of
-                GroupMatchesCard state ->
-                    let
-                        isActive =
-                            cardIdx == currentIdx
-
-                        isComplete =
-                            Form.GroupMatches.isComplete state.group model.bet
-
-                        label =
-                            if isActive then
-                                Group.toString state.group ++ "*"
-
-                            else
-                                Group.toString state.group
-
-                        clr =
-                            if isActive then
-                                Color.orange
-
-                            else if isComplete then
-                                Color.green
-
-                            else
-                                Color.grey
-                    in
-                    Element.el
-                        [ Element.Events.onClick (NavigateTo cardIdx)
-                        , Element.pointer
-                        , Font.color clr
-                        , UI.Font.mono
-                        ]
-                        (Element.text label)
-
-                _ ->
-                    Element.none
-    in
-    if isInGroupSection then
-        Element.wrappedRow [ Element.spacing 8 ]
-            (List.map viewGroupLetter groupCardsWithIndex)
-
-    else
-        Element.none
-
 
 viewCardChrome : Model Msg -> Element.Element Msg -> Int -> Element.Element Msg
 viewCardChrome model card i =
@@ -371,27 +273,6 @@ viewCardChrome model card i =
         checkboxArea =
             Element.column [ Element.spacing 4, Element.width Element.fill ]
                 [ viewTopCheckboxes model i
-                , viewGroupSubIndicators model i
-                ]
-
-        isGroupCard =
-            List.drop i model.cards
-                |> List.head
-                |> Maybe.map
-                    (\c ->
-                        case c of
-                            GroupMatchesCard _ ->
-                                True
-
-                            _ ->
-                                False
-                    )
-                |> Maybe.withDefault False
-
-        groupNav =
-            Element.row [ Element.spacing 20, Element.centerX ]
-                [ UI.Button.pillSmall UI.Style.Focus (NavigateTo prev) "< groep"
-                , UI.Button.pillSmall UI.Style.Focus (NavigateTo next) "groep >"
                 ]
 
         columnAttrs =
@@ -404,8 +285,4 @@ viewCardChrome model card i =
                 )
             ]
     in
-    if isGroupCard then
-        Element.column columnAttrs [ checkboxArea, card, groupNav ]
-
-    else
-        Element.column columnAttrs [ checkboxArea, nav, card ]
+    Element.column columnAttrs [ checkboxArea, nav, card ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -106,10 +106,10 @@ update msg model =
                 _ ->
                     ( model, Cmd.none )
 
-        GroupMatchMsg grp act ->
+        GroupMatchMsg act ->
             let
                 mCard =
-                    Cards.getGroupMatchesCard model.cards grp
+                    Cards.getGroupMatchesCard model.cards
             in
             case mCard of
                 Just (GroupMatchesCard groupMatchesState) ->
@@ -120,7 +120,7 @@ update msg model =
                                     , betState = Dirty
                                     , cards = Cards.updateGroupMatchesCard model.cards newState
                                   }
-                                , Cmd.map (GroupMatchMsg groupMatchesState.group) fx
+                                , Cmd.map GroupMatchMsg fx
                                 )
                            )
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -166,7 +166,7 @@ type Msg
     | FoundTimeZone Time.Zone
     | InfoMsg FormInfoMsg
       -- | QuestionSetMsg Page Form.QuestionSet.Msg
-    | GroupMatchMsg Group GroupMatches.Msg
+    | GroupMatchMsg GroupMatches.Msg
     | BracketMsg Bracket.Msg
     | TopscorerMsg Topscorer.Msg
     | ParticipantMsg Participant.Msg
@@ -246,15 +246,13 @@ type Access
 initCards : Screen.Size -> List Card
 initCards sz =
     let
-        createGroupMatchesCard ( g, mID ) =
-            GroupMatchesCard <| GroupMatches.init g mID
+        initGroupMatchesCards =
+            case Bets.Init.groupsAndFirstMatch of
+                ( _, firstMatchID ) :: _ ->
+                    [ GroupMatchesCard (GroupMatches.init firstMatchID) ]
 
-        firstCards =
-            let
-                groupmatchesCards =
-                    List.map createGroupMatchesCard Bets.Init.groupsAndFirstMatch
-            in
-            IntroCard Intro :: groupmatchesCards
+                [] ->
+                    []
 
         otherCards =
             [ BracketCard <| Bracket.init sz
@@ -263,7 +261,7 @@ initCards sz =
             , SubmitCard
             ]
     in
-    firstCards ++ otherCards
+    IntroCard Intro :: initGroupMatchesCards ++ otherCards
 
 
 


### PR DESCRIPTION
## Summary

- Replaces 12 separate `GroupMatchesCard` entries with a single combined card showing all 48 group matches through a 5-match scroll wheel
- Inline group nav row (A B* C … L) lets users jump to any group's first unentered match
- Group boundary separators (`-- X --`) appear in the scroll wheel at group transitions
- Progress counter (`12/48`) shown in the card footer
- Mobile swipe support via `touchstart`/`touchend` with 30px threshold

## Changes

- `GroupMatches.State` simplified to `{ cursor, touchStartY }` — no more `group`/`prev`/`next`
- `GroupMatchMsg` no longer carries a `Group` parameter
- `isComplete : Bet -> Bool` now checks all matches (not per-group)
- `viewGroupSubIndicators` removed from `Form/View.elm` (replaced by inline `viewGroupNav`)
- `getGroupMatchesCard` no longer takes a `Group` argument
- `allGroupsComplete` and `groupSectionTargetIndex` simplified for single card
- Total form card count reduced from 14 to 6

## Test plan

- [ ] 6 total cards: Intro, GroupMatches, Bracket, Topscorer, Participant, Submit
- [ ] Scroll wheel shows 5 matches centred on cursor with group separators at boundaries
- [ ] Entering a score auto-advances cursor to next match
- [ ] Clicking a match in the wheel selects it
- [ ] Clicking a group letter jumps to that group's first unentered match
- [ ] `[x]` shown in top checkboxes when all 48 matches are complete
- [ ] Progress counter updates correctly
- [ ] Mobile swipe up/down navigates the wheel

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)