### PR TITLE
Fix bracket completeness check (Issue #93)

### DIFF
--- a/src/Bets/Bet.elm
+++ b/src/Bets/Bet.elm
@@ -47,7 +47,7 @@ isComplete bet =
     Bool.all
         [ GroupMatches.isComplete bet.answers.matches
         , Topscorer.isComplete bet.answers.topscorer
-        , Bracket.isComplete bet.answers.bracket
+        , Bracket.isCompleteQualifiers bet.answers.bracket
         , Participant.isComplete bet.participant
         ]
 

--- a/src/Form/Bracket.elm
+++ b/src/Form/Bracket.elm
@@ -213,6 +213,15 @@ extractBestThirdSlots bracket =
 assignBestThirds : List ( Group, Team ) -> List ( String, List Group ) -> List ( String, Maybe Team )
 assignBestThirds thirdTeams tSlots =
     let
+        -- Sort by number of matching slots ascending (most constrained groups first)
+        -- This prevents a greedy failure where a group with few options loses its slot
+        -- to a group that had other alternatives.
+        countOptions grp =
+            List.length (List.filter (\( _, grps ) -> List.member grp grps) tSlots)
+
+        sortedThirdTeams =
+            List.sortBy (\( grp, _ ) -> countOptions grp) thirdTeams
+
         go remaining available acc =
             case remaining of
                 [] ->
@@ -231,7 +240,7 @@ assignBestThirds thirdTeams tSlots =
                         Nothing ->
                             go rest available acc
     in
-    go thirdTeams tSlots []
+    go sortedThirdTeams tSlots []
 
 
 setRoundWinners : List String -> List Team -> Bracket -> Bracket

--- a/src/Form/Bracket/View.elm
+++ b/src/Form/Bracket/View.elm
@@ -18,6 +18,7 @@ import Form.Bracket.Types
         , SelectionRound(..)
         , State
         , canSelectTeam
+        , countGroupInList
         , currentActiveRound
         , isWizardComplete
         , roundRequired
@@ -66,7 +67,7 @@ view _ state =
                 ]
 
         completionButton =
-            viewCompletionButton sel
+            viewCompletionButton sel allGroups teamData_
     in
     page "bracket"
         ([ stepper ] ++ sections ++ [ extroduction, completionButton ])
@@ -205,9 +206,13 @@ viewRoundSection activeRound sel allGroups teamData_ round =
         ]
 
 
-viewCompletionButton : RoundSelections -> Element Msg
-viewCompletionButton sel =
-    if isWizardComplete sel then
+viewCompletionButton : RoundSelections -> List Group -> TeamData -> Element Msg
+viewCompletionButton sel allGroups teamData_ =
+    let
+        allGroupsCovered =
+            List.all (\grp -> countGroupInList grp sel.lastThirtyTwo teamData_ >= 2) allGroups
+    in
+    if isWizardComplete sel && allGroupsCovered then
         Element.column [ centerX, spacing 8 ]
             [ Element.paragraph (UI.Style.introduction [])
                 [ Element.text "Je bracket is ingevuld!" ]


### PR DESCRIPTION
## Summary

- **Wrong completeness function**: `Bets.Bet.isComplete` used `Bracket.isComplete` which checks match `winner` fields — these are only set when the user's selected teams happen to align with specific R1 match pairings, which often they don't. Changed to `Bracket.isCompleteQualifiers` which checks TeamNode qualifiers set directly by `setBulk`.
- **Greedy T-slot assignment failure**: `assignBestThirds` processed groups A→L alphabetically, causing certain 8-group combinations (e.g. A,B,C,D,E,F,K,L) to fail — group L (only option: T3) would lose its slot to group D going first. Fixed by sorting `thirdTeams` by number of matching T-slots ascending before the greedy pass (most constrained groups first).
- **`isWizardComplete` too permissive**: Only checked `lastThirtyTwo == 32` and champion set, not that every group had ≥2 teams. A skipped group left W/R slots empty and `isCompleteQualifiers` returned False. `viewCompletionButton` now also requires all 12 groups to have ≥2 teams in `lastThirtyTwo` before showing "Ga verder →".

## Test plan

- [ ] Fill bracket wizard completely (champion → finalists → semis → quarters → last 16 → last 32 with ≥2 teams per group) — "Ga verder →" appears and submit enables
- [ ] Fill last 32 with only 1 team from one group — "Ga verder →" does not appear until corrected
- [ ] Verify bracket status bar indicator shows `[x]` when bracket is complete
- [ ] Submit button activates when all four sections (groups, bracket, topscorer, participant) are complete

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)