### PR TITLE
feat: convert bracket wizard to multipage experience

### DIFF
--- a/src/Form/Bracket.elm
+++ b/src/Form/Bracket.elm
@@ -15,8 +15,8 @@ import Form.Bracket.Types
         , SelectionRound(..)
         , State
         , addTeamToRound
-        , currentActiveRound
         , nextRound
+        , prevRound
         , removeTeamFromAll
         )
 import Form.Bracket.View
@@ -74,21 +74,22 @@ update msg bet state =
 
         GoNext ->
             let
-                currentRound =
-                    Maybe.withDefault (currentActiveRound wizardState.selections) wizardState.viewingRound
-
-                newViewingRound =
-                    nextRound currentRound
-
                 newState =
-                    { state | bracketState = BracketWizard { wizardState | viewingRound = Just newViewingRound } }
+                    { state | bracketState = BracketWizard { wizardState | currentPage = nextRound wizardState.currentPage } }
+            in
+            ( bet, newState, Cmd.none )
+
+        GoPrev ->
+            let
+                newState =
+                    { state | bracketState = BracketWizard { wizardState | currentPage = prevRound wizardState.currentPage } }
             in
             ( bet, newState, Cmd.none )
 
         JumpToRound round ->
             let
                 newState =
-                    { state | bracketState = BracketWizard { wizardState | viewingRound = Just round } }
+                    { state | bracketState = BracketWizard { wizardState | currentPage = round } }
             in
             ( bet, newState, Cmd.none )
 

--- a/src/Form/Bracket/Types.elm
+++ b/src/Form/Bracket/Types.elm
@@ -9,12 +9,12 @@ module Form.Bracket.Types exposing
     , addTeamToRound
     , canSelectTeam
     , countGroupInList
-    , currentActiveRound
     , emptyRoundSelections
     , init
     , initialKnockouts
     , isWizardComplete
     , nextRound
+    , prevRound
     , removeTeamFromAll
     , roundRequired
     , roundTeams
@@ -46,7 +46,7 @@ type alias RoundSelections =
 
 type alias WizardState =
     { selections : RoundSelections
-    , viewingRound : Maybe SelectionRound
+    , currentPage : SelectionRound
     }
 
 
@@ -71,6 +71,7 @@ type Msg
     = SelectTeam SelectionRound Team
     | DeselectTeam Team
     | GoNext
+    | GoPrev
     | JumpToRound SelectionRound
 
 
@@ -88,7 +89,7 @@ emptyRoundSelections =
 init : Screen.Size -> State
 init sz =
     { screen = sz
-    , bracketState = BracketWizard { selections = emptyRoundSelections, viewingRound = Nothing }
+    , bracketState = BracketWizard { selections = emptyRoundSelections, currentPage = LastThirtyTwoRound }
     }
 
 
@@ -161,6 +162,28 @@ nextRound round =
 
         ChampionRound ->
             ChampionRound
+
+
+prevRound : SelectionRound -> SelectionRound
+prevRound round =
+    case round of
+        LastThirtyTwoRound ->
+            LastThirtyTwoRound
+
+        LastSixteenRound ->
+            LastThirtyTwoRound
+
+        QuarterRound ->
+            LastSixteenRound
+
+        SemiRound ->
+            QuarterRound
+
+        FinalistRound ->
+            SemiRound
+
+        ChampionRound ->
+            FinalistRound
 
 
 addTeamToRound : SelectionRound -> Team -> RoundSelections -> RoundSelections
@@ -275,31 +298,6 @@ canSelectTeam round team sel teamData =
                     List.any (\t -> t.teamID == team.teamID) sel.finalists
     in
     hasCapacity && notAlreadyInRound && poolOk
-
-
-currentActiveRound : RoundSelections -> SelectionRound
-currentActiveRound sel =
-    let
-        championTeams =
-            Maybe.map List.singleton sel.champion |> Maybe.withDefault []
-
-        rounds =
-            [ ( LastThirtyTwoRound, sel.lastThirtyTwo, 32 )
-            , ( LastSixteenRound, sel.lastSixteen, 16 )
-            , ( QuarterRound, sel.quarters, 8 )
-            , ( SemiRound, sel.semis, 4 )
-            , ( FinalistRound, sel.finalists, 2 )
-            , ( ChampionRound, championTeams, 1 )
-            ]
-
-        isIncomplete ( _, teams, cap ) =
-            List.length teams < cap
-    in
-    rounds
-        |> List.filter isIncomplete
-        |> List.head
-        |> Maybe.map (\( r, _, _ ) -> r)
-        |> Maybe.withDefault ChampionRound
 
 
 isWizardComplete : RoundSelections -> Bool

--- a/src/Form/Bracket/View.elm
+++ b/src/Form/Bracket/View.elm
@@ -21,8 +21,6 @@ import Form.Bracket.Types
         , SelectionRound(..)
         , State
         , canSelectTeam
-        , currentActiveRound
-        , isWizardComplete
         , roundRequired
         , roundTeams
         )
@@ -44,9 +42,8 @@ view _ state =
         dev =
             Screen.device state.screen
 
-        -- viewingRound overrides currentActiveRound when user has tapped a completed step
         activeRound =
-            Maybe.withDefault (currentActiveRound wizardState.selections) wizardState.viewingRound
+            wizardState.currentPage
 
         sel =
             wizardState.selections
@@ -57,11 +54,8 @@ view _ state =
         allGroups =
             [ A, B, C, D, E, F, G, H, I, J, K, L ]
 
-        allRounds =
-            [ ChampionRound, FinalistRound, SemiRound, QuarterRound, LastSixteenRound, LastThirtyTwoRound ]
-
-        sections =
-            List.map (viewRoundSection activeRound sel allGroups teamData_ dev (round state.screen.width)) allRounds
+        section =
+            viewRoundSection activeRound sel allGroups teamData_ dev (round state.screen.width)
 
         extroduction =
             Element.column (UI.Style.introduction [ spacing 16 ])
@@ -72,25 +66,42 @@ view _ state =
                 , UI.Text.bulletText "13 punten voor de kampioen. "
                 ]
 
-        stickyButton =
-            if isWizardComplete sel then
+        isCurrentRoundComplete =
+            List.length (roundTeams activeRound sel) >= roundRequired activeRound
+
+        backButton =
+            if activeRound == LastThirtyTwoRound then
+                Element.none
+
+            else
                 Element.el
-                    [ Element.alignBottom
-                    , Element.width Element.fill
-                    , Element.padding 16
+                    [ Element.Events.onClick GoPrev
+                    , Element.pointer
+                    , Font.color Color.orange
+                    , UI.Font.mono
+                    , Font.size 12
+                    , Element.mouseOver [ Font.color Color.activeNav ]
                     ]
-                    (UI.Button.pill UI.Style.Focus GoNext "Ga verder \u{2192}")
+                    (Element.text "< vorige")
+
+        forwardButton =
+            if isCurrentRoundComplete then
+                UI.Button.pillSmall UI.Style.Focus GoNext "Ga verder \u{2192}"
 
             else
                 Element.none
+
+        roundNav =
+            Element.row
+                [ Element.width Element.fill
+                , Element.paddingXY 0 8
+                ]
+                [ backButton
+                , Element.el [ Element.alignRight ] forwardButton
+                ]
     in
-    Element.el
-        [ Element.inFront stickyButton
-        , Element.width Element.fill
-        ]
-        (page "bracket"
-            ([ stepper ] ++ sections ++ [ extroduction ])
-        )
+    page "bracket"
+        [ stepper, section, roundNav, extroduction ]
 
 
 viewBracketMinimap : SelectionRound -> RoundSelections -> Element Msg
@@ -178,8 +189,8 @@ viewBracketMinimap activeRound sel =
         )
 
 
-viewRoundSection : SelectionRound -> RoundSelections -> List Group -> TeamData -> Screen.Device -> Int -> SelectionRound -> Element Msg
-viewRoundSection activeRound sel allGroups teamData_ dev screenWidth round =
+viewRoundSection : SelectionRound -> RoundSelections -> List Group -> TeamData -> Screen.Device -> Int -> Element Msg
+viewRoundSection round sel allGroups teamData_ dev screenWidth =
     let
         teams =
             roundTeams round sel
@@ -190,9 +201,6 @@ viewRoundSection activeRound sel allGroups teamData_ dev screenWidth round =
         cap =
             roundRequired round
 
-        isActive =
-            round == activeRound
-
         isComplete =
             n >= cap
 
@@ -202,29 +210,10 @@ viewRoundSection activeRound sel allGroups teamData_ dev screenWidth round =
 
             else
                 String.fromInt n ++ "/" ++ String.fromInt cap ++ " geselecteerd"
-
-        header =
-            if isActive then
-                viewRoundBadge (roundTitle round) (roundDescription round) counterText
-
-            else
-                Element.column [ spacing 4 ]
-                    [ Element.row [ spacing 8 ]
-                        [ UI.Text.displayHeader (roundTitle round)
-                        , Element.el [ Font.color Color.grey, UI.Font.mono, Font.size 10 ] (Element.text counterText)
-                        ]
-                    ]
-
-        grid =
-            if isActive then
-                viewActiveGrid round sel allGroups teamData_ dev screenWidth
-
-            else
-                Element.none
     in
     Element.column [ spacing 12 ]
-        [ header
-        , grid
+        [ viewRoundBadge (roundTitle round) (roundDescription round) counterText
+        , viewActiveGrid round sel allGroups teamData_ dev screenWidth
         ]
 
 

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -65,10 +65,27 @@ viewCard model idx card =
                 next =
                     Basics.min (idx + 1) (List.length model.cards - 1)
 
+                prev =
+                    Basics.max (idx - 1) 0
+
+                (BracketTypes.BracketWizard ws) =
+                    bracketState.bracketState
+
                 mapBracketMsg msg =
                     case msg of
                         BracketTypes.GoNext ->
-                            NavigateTo next
+                            if ws.currentPage == BracketTypes.ChampionRound then
+                                NavigateTo next
+
+                            else
+                                BracketMsg BracketTypes.GoNext
+
+                        BracketTypes.GoPrev ->
+                            if ws.currentPage == BracketTypes.LastThirtyTwoRound then
+                                NavigateTo prev
+
+                            else
+                                BracketMsg BracketTypes.GoPrev
 
                         other ->
                             BracketMsg other

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -27,7 +27,7 @@ import Results.Topscorers
 import Task
 import Time
 import Ports
-import Form.Bracket.Types exposing (BracketState(..))
+import Form.Bracket.Types exposing (BracketState(..), SelectionRound(..))
 import TestData.Activities
 import TestData.Bet
 import TestData.MatchResults
@@ -1072,7 +1072,7 @@ update msg model =
                     , bracketState =
                         BracketWizard
                             { selections = TestData.Bet.dummyRoundSelections
-                            , viewingRound = Nothing
+                            , currentPage = LastThirtyTwoRound
                             }
                     }
 


### PR DESCRIPTION
## Summary

- Each `SelectionRound` (R32 → R16 → QF → SF → F → Champion) now has its own dedicated page — only the current round is shown at a time
- `WizardState.viewingRound : Maybe SelectionRound` replaced with `currentPage : SelectionRound` (cleaner type, no vestigial `Maybe`)
- Added `GoPrev` message and `prevRound` function for backward round navigation
- Boundary transitions handled in `Form/View.elm`: `GoNext` on Champion page exits to TopscorerCard; `GoPrev` on R32 page exits to GroupMatchesCard
- "Ga verder →" button gated on current round being complete (not full wizard complete)
- Back button hidden on R32 to avoid confusion with the card-level bottom nav
- Minimap remains as a clickable jump-to-round indicator
- Dead code removed: `currentActiveRound`, redundant `isActive` branches in `viewRoundSection`

## Test plan

- [ ] Navigate through all 6 rounds using "Ga verder →" — each round advances correctly
- [ ] "< vorige" button navigates backwards through rounds
- [ ] On R32, no "< vorige" button appears; the bottom nav "< vorige" goes to GroupMatchesCard
- [ ] On Champion round, "Ga verder →" exits to TopscorerCard
- [ ] Minimap dots jump directly to any round
- [ ] "Ga verder →" only appears when the current round has its required teams selected
- [ ] Progress rail and card chrome still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)