### PR TITLE
feat: UI polish round 1 — deeper dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ errors
 
 .gemini/
 gha-creds-*.json
+.superpowers/

--- a/prototypes/ui-polish-round1/form-details.html
+++ b/prototypes/ui-polish-round1/form-details.html
@@ -1,0 +1,177 @@
+<h2>Form Element Details — Deeper Dark</h2>
+<p class="subtitle">Detailed mockups of key form areas. Click any element you want to discuss or change.</p>
+
+<div class="section">
+  <h3>Navigation Bar</h3>
+  <div class="mockup">
+    <div class="mockup-header">Top Navigation</div>
+    <div class="mockup-body" style="padding:0;">
+      <div style="background:linear-gradient(180deg, #16171e 0%, #12131a 100%); font-family:'Courier New',monospace; font-size:11px; border-bottom:1px solid rgba(240,160,48,0.1); padding:12px 16px;">
+        <div style="color:#f0dfaf; font-size:13px; margin-bottom:10px; letter-spacing:1px; font-weight:bold;">Voetbalpool</div>
+        <div style="display:flex; gap:2px; flex-wrap:wrap;">
+          <span style="color:#7a7a70; padding:5px 12px;">home</span>
+          <span style="color:#7a7a70; padding:5px 12px;">stand</span>
+          <span style="color:#f0a030; background:rgba(240,160,48,0.12); padding:5px 12px; border-radius:4px; border-bottom:2px solid #f0a030;">formulier</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p style="color:#aaa; font-size:13px; margin-top:8px;">Active item: subtle orange background tint + bottom accent line. No more <code>> prefix</code>. Inactive: muted grey.</p>
+</div>
+
+<div class="section">
+  <h3>Progress Rail</h3>
+  <div class="mockup">
+    <div class="mockup-header">Step Progress</div>
+    <div class="mockup-body" style="padding:12px 16px; background:#0f1117;">
+      <div style="display:flex; gap:4px; align-items:end; font-family:'Courier New',monospace;">
+        <div style="flex:1; text-align:center;">
+          <div style="font-size:8px; color:#429f59; margin-bottom:5px;">intro</div>
+          <div style="height:3px; background:linear-gradient(90deg, #3a8a4e, #429f59); border-radius:2px;"></div>
+        </div>
+        <div style="flex:1; text-align:center;">
+          <div style="font-size:9px; color:#f0a030; margin-bottom:5px; font-weight:bold;">groepen</div>
+          <div style="height:4px; background:linear-gradient(90deg, #d08820, #f0a030); border-radius:3px; box-shadow:0 0 8px rgba(240,160,48,0.5), 0 0 2px rgba(240,160,48,0.3);"></div>
+        </div>
+        <div style="flex:1; text-align:center;">
+          <div style="font-size:8px; color:#444; margin-bottom:5px;">schema</div>
+          <div style="height:3px; background:#222; border-radius:2px;"></div>
+        </div>
+        <div style="flex:1; text-align:center;">
+          <div style="font-size:8px; color:#444; margin-bottom:5px;">topscorer</div>
+          <div style="height:3px; background:#222; border-radius:2px;"></div>
+        </div>
+        <div style="flex:1; text-align:center;">
+          <div style="font-size:8px; color:#444; margin-bottom:5px;">gegevens</div>
+          <div style="height:3px; background:#222; border-radius:2px;"></div>
+        </div>
+        <div style="flex:1; text-align:center;">
+          <div style="font-size:8px; color:#444; margin-bottom:5px;">inzenden</div>
+          <div style="height:3px; background:#222; border-radius:2px;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p style="color:#aaa; font-size:13px; margin-top:8px;">Active step: slightly taller bar (4px vs 3px), glow shadow, bolder label. Completed: green gradient. Future: dark, no alpha trick.</p>
+</div>
+
+<div class="section">
+  <h3>Section Headers</h3>
+  <div class="mockup">
+    <div class="mockup-header">--- TITLE --- → Gradient Divider</div>
+    <div class="mockup-body" style="padding:16px; background:#0f1117; font-family:'Courier New',monospace;">
+      <div style="margin-bottom:20px;">
+        <div style="display:flex; align-items:center; gap:14px;">
+          <div style="flex:1; height:1px; background:linear-gradient(to right, transparent, rgba(240,160,48,0.3));"></div>
+          <span style="color:#f0dfaf; font-size:11px; letter-spacing:2.5px; white-space:nowrap;">WEDSTRIJDEN</span>
+          <div style="flex:1; height:1px; background:linear-gradient(to left, transparent, rgba(240,160,48,0.3));"></div>
+        </div>
+      </div>
+      <div>
+        <div style="display:flex; align-items:center; gap:14px;">
+          <div style="flex:1; height:1px; background:linear-gradient(to right, transparent, rgba(240,160,48,0.3));"></div>
+          <span style="color:#f0dfaf; font-size:11px; letter-spacing:2.5px; white-space:nowrap;">WIE BEN JIJ</span>
+          <div style="flex:1; height:1px; background:linear-gradient(to left, transparent, rgba(240,160,48,0.3));"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p style="color:#aaa; font-size:13px; margin-top:8px;">Lines fade from transparent to a warm orange, creating a centered title with elegant dividers. Title text stays uppercase monospace.</p>
+</div>
+
+<div class="section">
+  <h3>Scroll Wheel Match Row (Active)</h3>
+  <div class="mockup">
+    <div class="mockup-header">Group Matches — Active Row Highlight</div>
+    <div class="mockup-body" style="padding:8px 16px; background:#0f1117; font-family:'Courier New',monospace; font-size:11px;">
+      <!-- Inactive above -->
+      <div style="display:flex; align-items:center; height:44px; padding:0 8px; border:1px solid #1a1a20; background:#12131a; border-radius:2px; margin-bottom:4px;">
+        <div style="display:flex; align-items:center; gap:6px; width:120px;">
+          <span style="font-size:16px;">🇨🇦</span>
+          <span style="color:#429f59; font-size:11px;">Canada</span>
+        </div>
+        <div style="width:48px; text-align:center; color:#429f59;">2-1</div>
+        <div style="display:flex; align-items:center; gap:6px; justify-content:flex-end; width:120px;">
+          <span style="color:#429f59; font-size:11px;">Morocco</span>
+          <span style="font-size:16px;">🇲🇦</span>
+        </div>
+      </div>
+      <!-- Active row -->
+      <div style="display:flex; align-items:center; height:44px; padding:0 8px; border:1px solid rgba(240,160,48,0.3); background:rgba(240,160,48,0.06); border-radius:2px; margin-bottom:4px; box-shadow:0 0 12px rgba(240,160,48,0.08);">
+        <div style="display:flex; align-items:center; gap:6px; width:120px;">
+          <span style="font-size:16px;">🇺🇸</span>
+          <span style="color:#dcdccc; font-size:11px;">USA</span>
+        </div>
+        <div style="width:48px; text-align:center; color:#f0a030;">_-_</div>
+        <div style="display:flex; align-items:center; gap:6px; justify-content:flex-end; width:120px;">
+          <span style="color:#dcdccc; font-size:11px;">Chile</span>
+          <span style="font-size:16px;">🇨🇱</span>
+        </div>
+      </div>
+      <!-- Inactive below -->
+      <div style="display:flex; align-items:center; height:44px; padding:0 8px; border:1px solid #1a1a20; background:#12131a; border-radius:2px; margin-bottom:4px;">
+        <div style="display:flex; align-items:center; gap:6px; width:120px;">
+          <span style="font-size:16px;">🇲🇽</span>
+          <span style="color:#555; font-size:11px;">Mexico</span>
+        </div>
+        <div style="width:48px; text-align:center; color:#555;">_-_</div>
+        <div style="display:flex; align-items:center; gap:6px; justify-content:flex-end; width:120px;">
+          <span style="color:#555; font-size:11px;">Ecuador</span>
+          <span style="font-size:16px;">🇪🇨</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p style="color:#aaa; font-size:13px; margin-top:8px;">Active row: orange border glow + very subtle orange background tint. Completed rows: green text. Pending: dim grey. Match tiles have slightly rounded borders (2px).</p>
+</div>
+
+<div class="section">
+  <h3>Bottom Navigation (Consolidated)</h3>
+  <div class="mockup">
+    <div class="mockup-header">Single Bottom Bar (replaces current double nav)</div>
+    <div class="mockup-body" style="padding:0; font-family:'Courier New',monospace;">
+      <div style="border-top:1px solid rgba(240,160,48,0.08); padding:0 16px; background:linear-gradient(180deg, #12131a, #0f1017);">
+        <div style="display:flex; justify-content:space-between; align-items:center; height:50px; font-size:12px;">
+          <span style="color:#8a8a80;">< vorige</span>
+          <div style="text-align:center;">
+            <span style="color:#f0a030;">groepen</span>
+            <span style="color:#555; font-size:10px; margin-left:6px;">· 12 open</span>
+          </div>
+          <span style="color:#f0dfaf;">volgende ></span>
+        </div>
+      </div>
+      <div style="border-top:1px solid rgba(79,79,79,0.3); padding:5px 16px; background:#0c0d12;">
+        <div style="display:flex; justify-content:space-between; font-size:10px;">
+          <span style="color:#444;">formulier > groepen  stap 2/6</span>
+          <span style="color:#444;">v2026</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p style="color:#aaa; font-size:13px; margin-top:8px;">One nav bar with section label + completion status in center. Status bar below stays as breadcrumb. Previous direction dimmed when non-navigable.</p>
+</div>
+
+<div class="section">
+  <h3>Summary of Changes</h3>
+  <table style="width:100%; border-collapse:collapse; font-size:13px; color:#ccc;">
+    <thead>
+      <tr style="border-bottom:1px solid #444;">
+        <th style="text-align:left; padding:8px; color:#f0a030;">Element</th>
+        <th style="text-align:left; padding:8px; color:#f0a030;">Change</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Background</td><td style="padding:8px;">#3F3F3F → #0f1117 (near-black)</td></tr>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Panel bg</td><td style="padding:8px;">#353535 → #12131a (deep blue-black)</td></tr>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Nav bar bg</td><td style="padding:8px;">#2B2B2B → gradient #16171e→#12131a</td></tr>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Borders</td><td style="padding:8px;">#4F4F4F → rgba(240,160,48,0.1) on chrome, #1a1a20 on cards</td></tr>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Active nav</td><td style="padding:8px;">> prefix → tinted bg + bottom accent</td></tr>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Progress rail</td><td style="padding:8px;">2px flat → 3-4px rounded + glow on active</td></tr>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Section headers</td><td style="padding:8px;">--- TEXT --- → gradient fade lines</td></tr>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Active match</td><td style="padding:8px;">Orange border → orange border + glow + bg tint</td></tr>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Double bottom nav</td><td style="padding:8px;">Consolidated into single bar</td></tr>
+      <tr style="border-bottom:1px solid #333;"><td style="padding:8px;">Version footer</td><td style="padding:8px;">Removed (status bar already shows it)</td></tr>
+      <tr><td style="padding:8px;">Grey text</td><td style="padding:8px;">#6E6E6E → #555 (dimmer against darker bg)</td></tr>
+    </tbody>
+  </table>
+</div>

--- a/prototypes/ui-polish-round1/polish-direction.html
+++ b/prototypes/ui-polish-round1/polish-direction.html
@@ -1,0 +1,248 @@
+<h2>UI Polish Direction</h2>
+<p class="subtitle">Subtle refinements to the form chrome and overall navigation. Click the approach that feels right.</p>
+
+<div class="cards">
+  <div class="card" data-choice="a" onclick="toggleSelect(this)">
+    <div class="card-image">
+      <div style="background:#2a2a2a; border-radius:8px; overflow:hidden; font-family:'Courier New',monospace; font-size:11px;">
+        <!-- Current nav -->
+        <div style="background:#2b2b2b; border-bottom:1px solid #4f4f4f; padding:8px 12px;">
+          <div style="color:#f0dfaf; font-size:12px; margin-bottom:6px;">Voetbalpool</div>
+          <div style="display:flex; gap:8px; flex-wrap:wrap;">
+            <span style="color:#f0a030;">> home</span>
+            <span style="color:#dcdccc;">&nbsp; stand</span>
+            <span style="color:#dcdccc;">&nbsp; formulier</span>
+          </div>
+        </div>
+        <!-- Current progress rail -->
+        <div style="padding:8px 12px 4px;">
+          <div style="display:flex; gap:2px;">
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#429f59; margin-bottom:2px;">intro</div>
+              <div style="height:2px; background:#429f59;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#f0a030; margin-bottom:2px;">groepen</div>
+              <div style="height:2px; background:#f0a030;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#6e6e6e; opacity:0.35; margin-bottom:2px;">schema</div>
+              <div style="height:2px; background:#6e6e6e; opacity:0.35;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#6e6e6e; opacity:0.35; margin-bottom:2px;">topscorer</div>
+              <div style="height:2px; background:#6e6e6e; opacity:0.35;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#6e6e6e; opacity:0.35; margin-bottom:2px;">gegevens</div>
+              <div style="height:2px; background:#6e6e6e; opacity:0.35;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#6e6e6e; opacity:0.35; margin-bottom:2px;">inzenden</div>
+              <div style="height:2px; background:#6e6e6e; opacity:0.35;"></div>
+            </div>
+          </div>
+        </div>
+        <!-- Current header -->
+        <div style="padding:12px 12px;">
+          <div style="display:flex; gap:8px; align-items:center;">
+            <span style="color:#4f4f4f;">---</span>
+            <span style="color:#f0dfaf; font-size:10px; letter-spacing:1.8px;">WEDSTRIJDEN</span>
+            <span style="color:#4f4f4f;">---</span>
+          </div>
+        </div>
+        <!-- Current bottom nav (double) -->
+        <div style="border-top:1px solid #4f4f4f; padding:8px 12px; background:#3f3f3f; margin-top:40px;">
+          <div style="display:flex; justify-content:space-between; align-items:center;">
+            <span style="color:#f0dfaf;">< vorige</span>
+            <span style="color:#f0dfaf;">groepen [!]</span>
+            <span style="color:#f0dfaf;">volgende ></span>
+          </div>
+        </div>
+        <div style="border-top:1px solid #4f4f4f; padding:8px 12px; background:#3f3f3f;">
+          <div style="display:flex; justify-content:space-between; align-items:center;">
+            <span style="color:#f0dfaf;">< vorige</span>
+            <span style="color:#6e6e6e; font-size:10px;">stap 2/6 · 12 wedstrijden open</span>
+            <span style="color:#f0dfaf;">volgende ></span>
+          </div>
+        </div>
+        <!-- Status bar -->
+        <div style="border-top:1px solid #4f4f4f; padding:6px 12px; background:#3f3f3f;">
+          <div style="display:flex; justify-content:space-between;">
+            <span style="color:#6e6e6e; font-size:10px;">formulier > groepen  stap 2/6</span>
+            <span style="color:#6e6e6e; font-size:10px;">v2026</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card-body">
+      <h3>Current</h3>
+      <p>Terminal aesthetic with double bottom nav, thin progress rail, short dashes in headers. Functional but dense.</p>
+    </div>
+  </div>
+
+  <div class="card" data-choice="b" onclick="toggleSelect(this)">
+    <div class="card-image">
+      <div style="background:#1e1e22; border-radius:8px; overflow:hidden; font-family:'Courier New',monospace; font-size:11px;">
+        <!-- Polished nav -->
+        <div style="background:#1a1a1e; border-bottom:1px solid rgba(240,160,48,0.15); padding:10px 16px;">
+          <div style="color:#f0dfaf; font-size:12px; margin-bottom:8px; letter-spacing:0.5px;">Voetbalpool</div>
+          <div style="display:flex; gap:4px; flex-wrap:wrap;">
+            <span style="color:#f0a030; background:rgba(240,160,48,0.1); padding:4px 10px; border-radius:3px; border:1px solid rgba(240,160,48,0.2);">> home</span>
+            <span style="color:#9a9a90; padding:4px 10px;">&nbsp; stand</span>
+            <span style="color:#9a9a90; padding:4px 10px;">&nbsp; formulier</span>
+          </div>
+        </div>
+        <!-- Polished progress rail -->
+        <div style="padding:10px 16px 6px;">
+          <div style="display:flex; gap:3px;">
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#429f59; margin-bottom:4px;">intro</div>
+              <div style="height:3px; background:#429f59; border-radius:2px;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#f0a030; margin-bottom:4px;">groepen</div>
+              <div style="height:3px; background:#f0a030; border-radius:2px; box-shadow:0 0 6px rgba(240,160,48,0.4);"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#555; margin-bottom:4px;">schema</div>
+              <div style="height:3px; background:#333; border-radius:2px;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#555; margin-bottom:4px;">topscorer</div>
+              <div style="height:3px; background:#333; border-radius:2px;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#555; margin-bottom:4px;">gegevens</div>
+              <div style="height:3px; background:#333; border-radius:2px;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#555; margin-bottom:4px;">inzenden</div>
+              <div style="height:3px; background:#333; border-radius:2px;"></div>
+            </div>
+          </div>
+        </div>
+        <!-- Polished header -->
+        <div style="padding:14px 16px;">
+          <div style="display:flex; align-items:center; gap:12px;">
+            <div style="flex:1; height:1px; background:linear-gradient(to right, transparent, #4f4f4f);"></div>
+            <span style="color:#f0dfaf; font-size:10px; letter-spacing:2px; white-space:nowrap;">WEDSTRIJDEN</span>
+            <div style="flex:1; height:1px; background:linear-gradient(to left, transparent, #4f4f4f);"></div>
+          </div>
+        </div>
+        <!-- Content placeholder -->
+        <div style="height:40px;"></div>
+        <!-- Single consolidated bottom nav -->
+        <div style="border-top:1px solid rgba(240,160,48,0.12); padding:0 16px; background:#1a1a1e;">
+          <div style="display:flex; justify-content:space-between; align-items:center; height:48px;">
+            <span style="color:#f0dfaf;">< vorige</span>
+            <div style="text-align:center;">
+              <span style="color:#f0a030; font-size:11px;">groepen</span>
+              <span style="color:#555; font-size:10px; margin-left:6px;">· 12 open</span>
+            </div>
+            <span style="color:#f0dfaf;">volgende ></span>
+          </div>
+        </div>
+        <!-- Status bar -->
+        <div style="border-top:1px solid rgba(79,79,79,0.5); padding:5px 16px; background:#161619;">
+          <div style="display:flex; justify-content:space-between;">
+            <span style="color:#555; font-size:10px;">formulier > groepen  stap 2/6</span>
+            <span style="color:#555; font-size:10px;">v2026</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card-body">
+      <h3>Subtle Polish</h3>
+      <p>Same dark foundation. Single bottom nav, gradient dividers in headers, soft glow on active rail, slightly deeper background for more depth. Rounded rail bars.</p>
+    </div>
+  </div>
+
+  <div class="card" data-choice="c" onclick="toggleSelect(this)">
+    <div class="card-image">
+      <div style="background:#0f1117; border-radius:8px; overflow:hidden; font-family:'Courier New',monospace; font-size:11px;">
+        <!-- Richer nav -->
+        <div style="background:linear-gradient(180deg, #16171e 0%, #12131a 100%); border-bottom:1px solid rgba(240,160,48,0.1); padding:12px 16px;">
+          <div style="color:#f0dfaf; font-size:13px; margin-bottom:10px; letter-spacing:1px; font-weight:bold;">Voetbalpool</div>
+          <div style="display:flex; gap:2px; flex-wrap:wrap;">
+            <span style="color:#f0a030; background:rgba(240,160,48,0.12); padding:5px 12px; border-radius:4px; border-bottom:2px solid #f0a030;">home</span>
+            <span style="color:#7a7a70; padding:5px 12px;">stand</span>
+            <span style="color:#7a7a70; padding:5px 12px;">formulier</span>
+          </div>
+        </div>
+        <!-- Richer progress rail -->
+        <div style="padding:12px 16px 8px;">
+          <div style="display:flex; gap:4px; align-items:end;">
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#429f59; margin-bottom:5px;">intro</div>
+              <div style="height:4px; background:linear-gradient(90deg, #3a8a4e, #429f59); border-radius:2px;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:9px; color:#f0a030; margin-bottom:5px; font-weight:bold;">groepen</div>
+              <div style="height:5px; background:linear-gradient(90deg, #d08820, #f0a030); border-radius:3px; box-shadow:0 0 8px rgba(240,160,48,0.5), 0 0 2px rgba(240,160,48,0.3);"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#444; margin-bottom:5px;">schema</div>
+              <div style="height:3px; background:#222; border-radius:2px;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#444; margin-bottom:5px;">topscorer</div>
+              <div style="height:3px; background:#222; border-radius:2px;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#444; margin-bottom:5px;">gegevens</div>
+              <div style="height:3px; background:#222; border-radius:2px;"></div>
+            </div>
+            <div style="flex:1; text-align:center;">
+              <div style="font-size:8px; color:#444; margin-bottom:5px;">inzenden</div>
+              <div style="height:3px; background:#222; border-radius:2px;"></div>
+            </div>
+          </div>
+        </div>
+        <!-- Richer header with ornamental line -->
+        <div style="padding:16px 16px;">
+          <div style="display:flex; align-items:center; gap:14px;">
+            <div style="flex:1; height:1px; background:linear-gradient(to right, transparent, rgba(240,160,48,0.3));"></div>
+            <span style="color:#f0dfaf; font-size:11px; letter-spacing:2.5px; white-space:nowrap;">WEDSTRIJDEN</span>
+            <div style="flex:1; height:1px; background:linear-gradient(to left, transparent, rgba(240,160,48,0.3));"></div>
+          </div>
+        </div>
+        <!-- Content placeholder -->
+        <div style="height:40px;"></div>
+        <!-- Single nav with accent -->
+        <div style="border-top:1px solid rgba(240,160,48,0.08); padding:0 16px; background:linear-gradient(180deg, #12131a, #0f1017);">
+          <div style="display:flex; justify-content:space-between; align-items:center; height:50px;">
+            <span style="color:#8a8a80;">< vorige</span>
+            <div style="text-align:center;">
+              <span style="color:#f0a030; font-size:11px;">groepen</span>
+              <span style="color:#555; font-size:10px; margin-left:6px;">· 12 open</span>
+            </div>
+            <span style="color:#f0dfaf;">volgende ></span>
+          </div>
+        </div>
+        <!-- Status bar -->
+        <div style="border-top:1px solid rgba(79,79,79,0.3); padding:5px 16px; background:#0c0d12;">
+          <div style="display:flex; justify-content:space-between;">
+            <span style="color:#444; font-size:10px;">formulier > groepen  stap 2/6</span>
+            <span style="color:#444; font-size:10px;">v2026</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card-body">
+      <h3>Deeper Dark</h3>
+      <p>Near-black background with gradient layering. Active rail bar is taller + glowing. Nav uses underline accent instead of prefix. Orange-tinted gradient dividers. More premium feel.</p>
+    </div>
+  </div>
+</div>
+
+<div class="section" style="margin-top:24px;">
+  <h3>Changes common to B and C</h3>
+  <ul style="color:#aaa; line-height:1.8;">
+    <li><strong>Single bottom nav</strong> — consolidate the duplicate nav bars into one</li>
+    <li><strong>Gradient section dividers</strong> — replace <code>--- TITLE ---</code> with fade-in/out lines</li>
+    <li><strong>Rounded progress bars</strong> — softer rail segments with glow on active</li>
+    <li><strong>Remove duplicate version footer</strong> — status bar already shows v2026</li>
+    <li><strong>Active nav highlight</strong> — subtle background tint on active item</li>
+  </ul>
+</div>

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -172,41 +172,65 @@ viewProgressRail model currentIdx =
     let
         viewSegment i card =
             let
+                isCurrent =
+                    i == currentIdx
+
+                isPast =
+                    i < currentIdx
+
                 barColor =
-                    if i == currentIdx then
+                    if isCurrent then
                         Color.activeNav
 
-                    else if i < currentIdx then
+                    else if isPast then
                         Color.green
 
                     else
-                        Color.grey
+                        Element.rgb255 0x22 0x22 0x22
 
                 labelColor =
-                    if i == currentIdx then
+                    if isCurrent then
                         Color.activeNav
 
-                    else if i < currentIdx then
+                    else if isPast then
                         Color.green
 
                     else
-                        Color.grey
+                        Element.rgb255 0x44 0x44 0x44
 
-                alphaAttrs =
-                    if i > currentIdx then
-                        [ Element.alpha 0.35 ]
+                barHeight =
+                    if isCurrent then
+                        4
+
+                    else if isPast then
+                        3
+
+                    else
+                        3
+
+                glowAttr =
+                    if isCurrent then
+                        [ Element.htmlAttribute (Html.Attributes.style "box-shadow" "0 0 8px rgba(240,160,48,0.5), 0 0 2px rgba(240,160,48,0.3)") ]
 
                     else
                         []
 
+                labelWeight =
+                    if isCurrent then
+                        Font.bold
+
+                    else
+                        Font.regular
+
                 barAttrs =
                     [ Element.width Element.fill
-                    , Element.height (Element.px 2)
+                    , Element.height (Element.px barHeight)
                     , Background.color barColor
+                    , Border.rounded 2
                     , Element.Events.onClick (NavigateTo i)
                     , Element.pointer
                     ]
-                        ++ alphaAttrs
+                        ++ glowAttr
 
                 labelAttrs =
                     [ Element.width Element.fill
@@ -215,11 +239,11 @@ viewProgressRail model currentIdx =
                     , Font.center
                     , Font.color labelColor
                     , UI.Font.mono
+                    , labelWeight
                     , Element.Events.onClick (NavigateTo i)
                     , Element.pointer
-                    , Element.paddingEach { bottom = 3, top = 0, left = 0, right = 0 }
+                    , Element.paddingEach { bottom = 4, top = 0, left = 0, right = 0 }
                     ]
-                        ++ alphaAttrs
             in
             Element.column
                 [ Element.width (Element.fillPortion 1) ]
@@ -229,8 +253,8 @@ viewProgressRail model currentIdx =
     in
     Element.row
         [ Element.width Element.fill
-        , Element.spacing 2
-        , Element.paddingXY 0 4
+        , Element.spacing 3
+        , Element.paddingXY 0 6
         ]
         (List.indexedMap viewSegment model.cards)
 
@@ -261,109 +285,6 @@ cardLabel card =
             "inzenden"
 
 
-incompleteIndicator : Model Msg -> Card -> String
-incompleteIndicator model card =
-    case card of
-        GroupMatchesCard _ ->
-            if allGroupsComplete model then
-                ""
-
-            else
-                " [!]"
-
-        BracketCard _ ->
-            if Form.Bracket.isCompleteQualifiers model.bet then
-                ""
-
-            else
-                " [!]"
-
-        TopscorerCard _ ->
-            if Form.Topscorer.isComplete model.bet then
-                ""
-
-            else
-                " [!]"
-
-        ParticipantCard _ ->
-            if Form.Participant.isComplete model.bet then
-                ""
-
-            else
-                " [!]"
-
-        _ ->
-            ""
-
-
-viewBottomNav : Model Msg -> Int -> Element.Element Msg
-viewBottomNav model currentIdx =
-    let
-        totalCards =
-            List.length model.cards
-
-        lastIdx =
-            totalCards - 1
-
-        currentCard =
-            List.drop currentIdx model.cards
-                |> List.head
-                |> Maybe.withDefault DashboardCard
-
-        disabledAttrs =
-            [ Element.alpha 0.35
-            , Element.htmlAttribute (Html.Attributes.style "cursor" "not-allowed")
-            ]
-
-        activeAttrs target =
-            [ Element.pointer
-            , Element.Events.onClick (NavigateTo target)
-            , Element.mouseOver [ Font.color Color.activeNav ]
-            ]
-
-        prevButton =
-            if currentIdx == 0 then
-                Element.el
-                    ([ Font.color Color.grey, UI.Font.mono, Font.size 12 ] ++ disabledAttrs)
-                    (Element.text "< vorige")
-
-            else
-                Element.el
-                    ([ Font.color Color.orange, UI.Font.mono, Font.size 12 ] ++ activeAttrs (currentIdx - 1))
-                    (Element.text "< vorige")
-
-        nextButton =
-            if currentIdx == lastIdx then
-                Element.el
-                    ([ Font.color Color.grey, UI.Font.mono, Font.size 12, Element.alignRight ] ++ disabledAttrs)
-                    (Element.text "volgende >")
-
-            else
-                Element.el
-                    ([ Font.color Color.orange, UI.Font.mono, Font.size 12, Element.alignRight ] ++ activeAttrs (currentIdx + 1))
-                    (Element.text "volgende >")
-
-        centerLabel =
-            Element.el
-                [ Element.centerX, UI.Font.mono, Font.color Color.orange, Font.size 12 ]
-                (Element.text (cardLabel currentCard ++ incompleteIndicator model currentCard))
-    in
-    Element.el
-        [ Element.width Element.fill
-        , Element.alignBottom
-        , Background.color (Element.rgb255 0x2B 0x2B 0x2B)
-        , Element.paddingXY 16 0
-        , Element.height (Element.px 56)
-        , Border.color Color.terminalBorder
-        , Border.widthEach { top = 1, bottom = 0, left = 0, right = 0 }
-        ]
-        (Element.row
-            [ Element.width Element.fill
-            , Element.height Element.fill
-            , Element.centerY
-            ]
-            [ prevButton, centerLabel, nextButton ]
-        )
 
 
 viewCardChrome : Model Msg -> Element.Element Msg -> Int -> Element.Element Msg
@@ -381,7 +302,6 @@ viewCardChrome model card i =
                     |> Element.maximum (Screen.maxWidth model.screen)
                 )
             , Element.paddingEach { top = 0, right = 0, bottom = 72, left = 0 }
-            , Element.inFront (viewBottomNav model i)
             ]
     in
     Element.column columnAttrs [ railArea, card ]

--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -15,7 +15,8 @@ module UI.Button exposing
 
 import Bets.Types
 import Element exposing (Element, alignLeft, alignRight, centerX, centerY, fill, height, padding, paddingXY, px, spacing, text, width)
-import Element.Border exposing (rounded)
+import Element.Background as Background
+import Element.Border as Border exposing (rounded)
 import Element.Events exposing (onClick)
 import Element.Font as Font
 import UI.Color as Color
@@ -45,18 +46,22 @@ navlink semantics link linkText =
                     [ UI.Font.mono
                     , Font.color Color.activeNav
                     , Font.size (UI.Font.scaled 1)
-                    , paddingXY 8 4
+                    , paddingXY 12 5
                     , height (px 44)
                     , centerX
                     , centerY
                     , Element.pointer
+                    , Background.color (Element.rgba255 0xF0 0xA0 0x30 0.12)
+                    , Border.rounded 4
+                    , Border.widthEach { bottom = 2, top = 0, left = 0, right = 0 }
+                    , Border.color Color.activeNav
                     ]
 
                 _ ->
                     [ UI.Font.mono
-                    , Font.color Color.primaryText
+                    , Font.color (Element.rgb255 0x7A 0x7A 0x70)
                     , Font.size (UI.Font.scaled 1)
-                    , paddingXY 8 4
+                    , paddingXY 12 5
                     , height (px 44)
                     , centerX
                     , centerY

--- a/src/UI/Color.elm
+++ b/src/UI/Color.elm
@@ -67,17 +67,17 @@ red =
 
 black : Color
 black =
-    rgb255 0x3F 0x3F 0x3F
+    rgb255 0x0F 0x11 0x17
 
 
 dark_red : Color
 dark_red =
-    rgb255 28 28 28
+    rgb255 0x0C 0x0D 0x12
 
 
 dark_blue : Color
 dark_blue =
-    rgb255 20 20 20
+    rgb255 0x0A 0x0B 0x10
 
 
 light_blue : Color
@@ -87,23 +87,17 @@ light_blue =
 
 grey : Color
 grey =
-    rgb255 110 110 110
+    rgb255 0x55 0x55 0x55
 
 
 shadow : Color
 shadow =
-    rgb255 13 13 13
+    rgb255 8 8 12
 
 
 potential : Color
 potential =
     white
-
-
-
--- browngrey : Color
--- browngrey =
---     rgb255 215 204 200
 
 
 white : Color
@@ -148,17 +142,17 @@ selected =
 
 primary : Color
 primary =
-    rgb255 0x2A 0x2A 0x2A
+    rgb255 0x14 0x15 0x1C
 
 
 primaryDark : Color
 primaryDark =
-    rgb255 0x35 0x35 0x35
+    rgb255 0x12 0x13 0x1A
 
 
 primaryLight : Color
 primaryLight =
-    rgb255 0x55 0x55 0x55
+    rgb255 0x22 0x23 0x2A
 
 
 secondary : Color
@@ -186,19 +180,14 @@ secondaryText =
     orange
 
 
-
--- rgb255 0x4E 0x34 0x2E
--- rgb255 0 150 136
-
-
 panel : Color
 panel =
-    rgb255 0x3A 0x3A 0x3A
+    rgb255 0x1A 0x1A 0x20
 
 
 terminalBorder : Color
 terminalBorder =
-    rgb255 0x4F 0x4F 0x4F
+    rgb255 0x2A 0x2A 0x32
 
 
 terminalAccentDim : Color

--- a/src/UI/Style.elm
+++ b/src/UI/Style.elm
@@ -236,7 +236,7 @@ introduction attrs =
            , Element.paddingEach { top = 10, bottom = 10, left = 14, right = 14 }
            , Border.widthEach { bottom = 0, top = 0, left = 2, right = 0 }
            , Border.color Color.activeNav
-           , Background.color (Element.rgba255 0xF0 0xA0 0x30 0.04)
+           , Background.color (Element.rgba255 0xF0 0xA0 0x30 0.06)
            ]
 
 
@@ -750,18 +750,34 @@ matchRowTile isActive attrs =
     let
         borderColor =
             if isActive then
-                Color.orange
+                Element.rgba255 0xF0 0xA0 0x30 0.3
 
             else
                 Color.terminalBorder
+
+        bgColor =
+            if isActive then
+                Element.rgba255 0xF0 0xA0 0x30 0.06
+
+            else
+                Color.primaryDark
+
+        glowAttr =
+            if isActive then
+                [ Element.htmlAttribute (Html.Attributes.style "box-shadow" "0 0 12px rgba(240,160,48,0.08)") ]
+
+            else
+                []
     in
     attrs
         ++ [ Border.width 1
            , Border.color borderColor
-           , Background.color Color.primaryDark
+           , Background.color bgColor
+           , Border.rounded 2
            , Element.width Element.fill
            , Element.paddingXY 8 0
            ]
+        ++ glowAttr
 
 
 kopje : List (Element.Attribute msg) -> List (Element.Attribute msg)

--- a/src/UI/Text.elm
+++ b/src/UI/Text.elm
@@ -13,8 +13,10 @@ module UI.Text exposing
     )
 
 import Element exposing (alignLeft, alignTop, spacing, width, centerX, centerY)
+import Element.Background as Background
 import Element.Font as Font
 import Element.Input as Input
+import Html.Attributes
 import Time exposing (Month(..), Weekday(..))
 import UI.Color as Color
 import UI.Font as UIFont
@@ -34,28 +36,33 @@ textSecondary txt =
 displayHeader : String -> Element.Element msg
 displayHeader txt =
     let
-        dashStyle =
-            [ UIFont.mono
-            , Font.size 10
-            , Font.color Color.terminalBorder
-            , Font.letterSpacing 1.8
-            ]
+        gradientLine direction =
+            Element.el
+                [ Element.width Element.fill
+                , Element.height (Element.px 1)
+                , Element.htmlAttribute
+                    (Html.Attributes.style "background"
+                        ("linear-gradient(to " ++ direction ++ ", transparent, rgba(240,160,48,0.3))")
+                    )
+                ]
+                Element.none
 
         titleStyle =
             [ UIFont.mono
-            , Font.size 10
+            , Font.size 11
             , Font.color Color.orange
-            , Font.letterSpacing 1.8
+            , Font.letterSpacing 2.5
             ]
     in
     Element.row
         [ Element.width Element.fill
-        , Element.paddingXY 0 10
-        , Element.spacing 8
+        , Element.paddingXY 0 14
+        , Element.spacing 14
+        , Element.centerY
         ]
-        [ Element.el dashStyle (Element.text "---")
+        [ gradientLine "right"
         , Element.el titleStyle (Element.text (String.toUpper txt))
-        , Element.el dashStyle (Element.text "---")
+        , gradientLine "left"
         ]
 
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -10,6 +10,7 @@ import Element.Background as Background
 import Element.Border as Border
 import Element.Events
 import Element.Font as Font exposing (Font)
+import Html.Attributes
 import Form.Bracket
 import Form.Bracket.Types as BracketTypes
 import Form.GroupMatches
@@ -105,13 +106,6 @@ view model =
                     else
                         UI.Style.Potential
 
-                prefix =
-                    if isActive then
-                        "> "
-
-                    else
-                        "  "
-
                 ( linkUrl, linkText ) =
                     case app of
                         Home ->
@@ -147,8 +141,7 @@ view model =
                         _ ->
                             ( "#home", "home" )
             in
-            -- Element.el [] wrapper for wrapperrow alignment misbehaviour
-            Element.el [] <| UI.Button.navlink semantics linkUrl (prefix ++ linkText)
+            Element.el [] <| UI.Button.navlink semantics linkUrl linkText
 
         linkList =
             if model.testMode then
@@ -165,9 +158,9 @@ view model =
         links =
             Element.column
                 [ Element.width Element.fill
-                , Background.color (Element.rgb255 0x2B 0x2B 0x2B)
+                , Element.htmlAttribute (Html.Attributes.style "background" "linear-gradient(180deg, #16171e 0%, #12131a 100%)")
                 , Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
-                , Border.color Color.terminalBorder
+                , Border.color (Element.rgba255 0xF0 0xA0 0x30 0.1)
                 ]
                 [ Element.row
                     [ Element.width Element.fill
@@ -178,13 +171,14 @@ view model =
                         , Element.pointer
                         , Font.color Color.orange
                         , UI.Font.mono
-                        , Font.size 12
-                        , Font.letterSpacing 0.1
+                        , Font.size 13
+                        , Font.letterSpacing 1.0
+                        , Font.bold
                         , Element.paddingXY 0 8
                         ]
                         (Element.text "Voetbalpool")
                     ]
-                , Element.wrappedRow [ Element.paddingXY 0 8, Element.spacing 4 ]
+                , Element.wrappedRow [ Element.paddingXY 0 8, Element.spacing 2 ]
                     (List.map link linkList)
                 ]
 
@@ -206,7 +200,6 @@ view model =
                 ]
                 [ links
                 , contents
-                , viewVersion
                 ]
 
         body =
@@ -284,15 +277,42 @@ viewInstallBanner model =
                 ]
 
 
-cardCenterInfo : Model Msg -> String
-cardCenterInfo model =
+cardLabel : Model Msg -> String
+cardLabel model =
     let
-        stepStr =
-            "stap "
-                ++ String.fromInt (model.idx + 1)
-                ++ "/"
-                ++ String.fromInt (List.length model.cards)
+        currentCard =
+            List.drop model.idx model.cards
+                |> List.head
+    in
+    case currentCard of
+        Just DashboardCard ->
+            "overzicht"
 
+        Just (IntroCard _) ->
+            "intro"
+
+        Just (GroupMatchesCard _) ->
+            "groepen"
+
+        Just (BracketCard _) ->
+            "schema"
+
+        Just (TopscorerCard _) ->
+            "topscorer"
+
+        Just (ParticipantCard _) ->
+            "gegevens"
+
+        Just SubmitCard ->
+            "inzenden"
+
+        Nothing ->
+            ""
+
+
+cardStatusSuffix : Model Msg -> String
+cardStatusSuffix model =
+    let
         currentCard =
             List.drop model.idx model.cards
                 |> List.head
@@ -305,10 +325,10 @@ cardCenterInfo model =
                         |> List.length
             in
             if openCount > 0 then
-                stepStr ++ " · " ++ String.fromInt openCount ++ " wedstrijden open"
+                String.fromInt openCount ++ " open"
 
             else
-                stepStr ++ " [x]"
+                "klaar"
 
         Just (BracketCard { bracketState }) ->
             case bracketState of
@@ -332,27 +352,27 @@ cardCenterInfo model =
                                 |> List.length
                     in
                     if openRounds == 0 then
-                        stepStr ++ " [x]"
+                        "klaar"
 
                     else
-                        stepStr ++ " · " ++ String.fromInt openRounds ++ " ronden open"
+                        String.fromInt openRounds ++ " ronden open"
 
         Just (TopscorerCard _) ->
             if Form.Topscorer.isComplete model.bet then
-                stepStr ++ " [x]"
+                "klaar"
 
             else
-                stepStr ++ " · 1 open"
+                "1 open"
 
         Just (ParticipantCard _) ->
             if Form.Participant.isComplete model.bet then
-                stepStr ++ " [x]"
+                "klaar"
 
             else
-                stepStr ++ " · gegevens open"
+                "gegevens open"
 
         _ ->
-            stepStr
+            "stap " ++ String.fromInt (model.idx + 1) ++ "/" ++ String.fromInt (List.length model.cards)
 
 
 viewFormNavBar : Model Msg -> Element.Element Msg
@@ -374,19 +394,21 @@ viewFormNavBar model =
 
                 prevButton =
                     Element.el
-                        [ Element.height (Element.px 48)
+                        [ Element.height (Element.px 50)
                         , Element.centerY
-                        , Font.color Color.grey
+                        , Font.color (Element.rgb255 0x8A 0x8A 0x80)
                         , UI.Font.mono
+                        , Font.size 12
                         ]
                         (UI.Text.allCenteredText "< vorige")
 
                 nextButton =
                     Element.el
-                        [ Element.height (Element.px 48)
+                        [ Element.height (Element.px 50)
                         , Element.centerY
-                        , Font.color Color.grey
+                        , Font.color (Element.rgb255 0x8A 0x8A 0x80)
                         , UI.Font.mono
+                        , Font.size 12
                         ]
                         (UI.Text.allCenteredText "volgende >")
 
@@ -394,10 +416,11 @@ viewFormNavBar model =
                     Element.el
                         [ Element.Events.onClick (NavigateTo prev)
                         , Element.pointer
-                        , Element.height (Element.px 48)
+                        , Element.height (Element.px 50)
                         , Element.centerY
                         , Font.color Color.orange
                         , UI.Font.mono
+                        , Font.size 12
                         , Element.mouseOver [ Font.color Color.white ]
                         ]
                         (UI.Text.allCenteredText "< vorige")
@@ -406,87 +429,48 @@ viewFormNavBar model =
                     Element.el
                         [ Element.Events.onClick (NavigateTo next)
                         , Element.pointer
-                        , Element.height (Element.px 48)
+                        , Element.height (Element.px 50)
                         , Element.centerY
                         , Font.color Color.orange
                         , UI.Font.mono
+                        , Font.size 12
                         , Element.mouseOver [ Font.color Color.white ]
                         ]
                         (UI.Text.allCenteredText "volgende >")
 
-                centerInfo =
-                    cardCenterInfo model
             in
-            case Screen.device model.screen of
-                Screen.Phone ->
-                    Element.column
-                        [ Element.width Element.fill
-                        , Background.color Color.black
-                        , Border.widthEach { top = 1, bottom = 0, left = 0, right = 0 }
-                        , Border.color Color.terminalBorder
+            Element.row
+                [ Element.width Element.fill
+                , Element.paddingXY 16 0
+                , Element.height (Element.px 50)
+                , Element.htmlAttribute (Html.Attributes.style "background" "linear-gradient(180deg, #12131a, #0f1017)")
+                , Border.widthEach { top = 1, bottom = 0, left = 0, right = 0 }
+                , Border.color (Element.rgba255 0xF0 0xA0 0x30 0.08)
+                ]
+                [ Element.el
+                    [ Element.width (Element.fillPortion 1)
+                    , Element.height (Element.px 50)
+                    , Element.centerY
+                    ]
+                    (if isFirst then prevButton else activePrevButton)
+                , Element.el
+                    [ Element.width (Element.fillPortion 2)
+                    , Element.centerX
+                    , UI.Font.mono
+                    ]
+                    (Element.row [ Element.centerX, Element.centerY, Element.spacing 6 ]
+                        [ Element.el [ Font.color Color.activeNav, Font.size 11 ] (Element.text (cardLabel model))
+                        , Element.el [ Font.color (Element.rgb255 0x55 0x55 0x55), Font.size 10 ] (Element.text ("· " ++ cardStatusSuffix model))
                         ]
-                        [ Element.row
-                            [ Element.width Element.fill
-                            , Element.paddingXY 12 0
-                            , Element.height (Element.px 48)
-                            ]
-                            [ Element.el
-                                [ Element.width (Element.fillPortion 1)
-                                , Element.height (Element.px 48)
-                                , Element.centerY
-                                ]
-                                (if isFirst then prevButton else activePrevButton)
-                            , Element.el
-                                [ Element.width (Element.fillPortion 1)
-                                , Element.height (Element.px 48)
-                                , Element.centerY
-                                , Element.alignRight
-                                ]
-                                (if isLast then nextButton else activeNextButton)
-                            ]
-                        , Element.el
-                            [ Element.width Element.fill
-                            , Element.paddingXY 12 8
-                            , Font.color Color.grey
-                            , UI.Font.mono
-                            , Font.size (UI.Font.scaled 0)
-                            , Border.widthEach { top = 1, bottom = 0, left = 0, right = 0 }
-                            , Border.color Color.terminalBorder
-                            ]
-                            (UI.Text.allCenteredText centerInfo)
-                        ]
-
-                Screen.Computer ->
-                    Element.row
-                        [ Element.width Element.fill
-                        , Element.paddingXY 12 0
-                        , Element.height (Element.px 48)
-                        , Background.color Color.black
-                        , Border.widthEach { top = 1, bottom = 0, left = 0, right = 0 }
-                        , Border.color Color.terminalBorder
-                        ]
-                        [ Element.el
-                            [ Element.width (Element.fillPortion 1)
-                            , Element.height (Element.px 48)
-                            , Element.centerY
-                            ]
-                            (if isFirst then prevButton else activePrevButton)
-                        , Element.el
-                            [ Element.width (Element.fillPortion 2)
-                            , Element.centerX
-                            , Font.color Color.grey
-                            , UI.Font.mono
-                            , Font.size (UI.Font.scaled 0)
-                            ]
-                            (UI.Text.allCenteredText centerInfo)
-                        , Element.el
-                            [ Element.width (Element.fillPortion 1)
-                            , Element.height (Element.px 48)
-                            , Element.centerY
-                            , Element.alignRight
-                            ]
-                            (if isLast then nextButton else activeNextButton)
-                        ]
+                    )
+                , Element.el
+                    [ Element.width (Element.fillPortion 1)
+                    , Element.height (Element.px 50)
+                    , Element.centerY
+                    , Element.alignRight
+                    ]
+                    (if isLast then nextButton else activeNextButton)
+                ]
 
         _ ->
             Element.none
@@ -578,12 +562,12 @@ viewStatusBar model =
     in
     Element.row
         [ Element.width Element.fill
-        , Element.paddingXY 12 6
-        , Background.color Color.black
+        , Element.paddingXY 16 5
+        , Background.color Color.dark_red
         , Border.widthEach { top = 1, bottom = 0, left = 0, right = 0 }
-        , Border.color Color.terminalBorder
+        , Border.color (Element.rgba255 0x4F 0x4F 0x4F 0.3)
         ]
-        [ Element.el [ Font.color Color.grey, UI.Font.mono, Font.size (UI.Font.scaled 0) ]
+        [ Element.el [ Font.color (Element.rgb255 0x44 0x44 0x44), UI.Font.mono, Font.size (UI.Font.scaled 0) ]
             (Element.text statusText)
         , Element.el
             [ Element.alignRight
@@ -592,7 +576,7 @@ viewStatusBar model =
                     Color.orange
 
                  else
-                    Color.grey
+                    Element.rgb255 0x44 0x44 0x44
                 )
             , UI.Font.mono
             , Font.size (UI.Font.scaled 0)


### PR DESCRIPTION
## Summary
- Shift color palette to near-black with blue undertone (#0F1117 body, #12131A panels)
- Replace `--- TITLE ---` section headers with gradient fade-in/out dividers
- Consolidate duplicate bottom nav bars into single bar with gradient background
- Add glow effects on active progress rail segment and active match rows
- Update nav links: underline accent + tinted bg instead of `> prefix`
- Remove duplicate version footer (status bar already shows v2026)

## Test plan
- [ ] Serve locally (`python3 -m http.server --directory build`) and verify all pages render
- [ ] Check form progression: intro → group matches → bracket → topscorer → participant → submit
- [ ] Verify bottom nav works correctly (single bar, prev/next navigation)
- [ ] Check progress rail glow on active step
- [ ] Verify gradient divider headers appear on all section titles
- [ ] Test on mobile viewport (< 500px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)