### PR TITLE
fix: bracket unselect removes team from round (#106)

### DIFF
--- a/src/Form/Bracket.elm
+++ b/src/Form/Bracket.elm
@@ -17,7 +17,7 @@ import Form.Bracket.Types
         , addTeamToRound
         , nextRound
         , prevRound
-        , removeTeamFromAll
+        , removeTeamFromRoundAndAbove
         )
 import Form.Bracket.View
 import List.Extra as Extra
@@ -56,10 +56,10 @@ update msg bet state =
             in
             ( newBet, newState, Cmd.none )
 
-        DeselectTeam team ->
+        DeselectTeam round team ->
             let
                 newSelections =
-                    removeTeamFromAll team wizardState.selections
+                    removeTeamFromRoundAndAbove round team wizardState.selections
 
                 newState =
                     { state | bracketState = BracketWizard { wizardState | selections = newSelections } }

--- a/src/Form/Bracket/Types.elm
+++ b/src/Form/Bracket/Types.elm
@@ -15,7 +15,7 @@ module Form.Bracket.Types exposing
     , isWizardComplete
     , nextRound
     , prevRound
-    , removeTeamFromAll
+    , removeTeamFromRoundAndAbove
     , roundRequired
     , roundTeams
     )
@@ -69,7 +69,7 @@ type IsWinner
 
 type Msg
     = SelectTeam SelectionRound Team
-    | DeselectTeam Team
+    | DeselectTeam SelectionRound Team
     | GoNext
     | GoPrev
     | JumpToRound SelectionRound
@@ -216,29 +216,42 @@ addTeamToRound round team sel =
             { sel | lastThirtyTwo = addUnique team sel.lastThirtyTwo }
 
 
-removeTeamFromAll : Team -> RoundSelections -> RoundSelections
-removeTeamFromAll team sel =
+removeTeamFromRoundAndAbove : SelectionRound -> Team -> RoundSelections -> RoundSelections
+removeTeamFromRoundAndAbove round team sel =
     let
         remove lst =
             List.filter (\t -> t.teamID /= team.teamID) lst
-    in
-    { champion =
-        case sel.champion of
-            Just c ->
-                if c.teamID == team.teamID then
+
+        removeChampion =
+            case sel.champion of
+                Just c ->
+                    if c.teamID == team.teamID then
+                        Nothing
+
+                    else
+                        Just c
+
+                Nothing ->
                     Nothing
+    in
+    case round of
+        ChampionRound ->
+            { sel | champion = removeChampion }
 
-                else
-                    Just c
+        FinalistRound ->
+            { sel | champion = removeChampion, finalists = remove sel.finalists }
 
-            Nothing ->
-                Nothing
-    , finalists = remove sel.finalists
-    , semis = remove sel.semis
-    , quarters = remove sel.quarters
-    , lastSixteen = remove sel.lastSixteen
-    , lastThirtyTwo = remove sel.lastThirtyTwo
-    }
+        SemiRound ->
+            { sel | champion = removeChampion, finalists = remove sel.finalists, semis = remove sel.semis }
+
+        QuarterRound ->
+            { sel | champion = removeChampion, finalists = remove sel.finalists, semis = remove sel.semis, quarters = remove sel.quarters }
+
+        LastSixteenRound ->
+            { sel | champion = removeChampion, finalists = remove sel.finalists, semis = remove sel.semis, quarters = remove sel.quarters, lastSixteen = remove sel.lastSixteen }
+
+        LastThirtyTwoRound ->
+            { sel | champion = removeChampion, finalists = remove sel.finalists, semis = remove sel.semis, quarters = remove sel.quarters, lastSixteen = remove sel.lastSixteen, lastThirtyTwo = remove sel.lastThirtyTwo }
 
 
 countGroupInList : Group -> List Team -> TeamData -> Int

--- a/src/Form/Bracket/View.elm
+++ b/src/Form/Bracket/View.elm
@@ -400,7 +400,7 @@ viewSelectableTeam round sel teamData_ team =
     if isPlaced then
         -- Orange border + tinted bg + orange text, tappable to deselect
         Element.el
-            [ Element.Events.onClick (DeselectTeam team)
+            [ Element.Events.onClick (DeselectTeam round team)
             , Element.pointer
             , Element.width Element.shrink
             , Element.height (Element.px 44)
@@ -499,7 +499,7 @@ viewCompactBadge round sel _ team =
     if isInRound then
         Element.el
             (baseAttrs
-                ++ [ Element.Events.onClick (DeselectTeam team)
+                ++ [ Element.Events.onClick (DeselectTeam round team)
                    , Element.pointer
                    ]
             )
@@ -589,7 +589,7 @@ viewWideBadge maxWidth round sel _ team =
     if isInRound then
         Element.el
             (baseAttrs
-                ++ [ Element.Events.onClick (DeselectTeam team)
+                ++ [ Element.Events.onClick (DeselectTeam round team)
                    , Element.pointer
                    ]
             )


### PR DESCRIPTION
## Summary
- **Bug**: Deselecting a team in R16+ rounds removed it from all rounds including feeder rounds, making the team vanish from the selectable pool entirely
- **Root cause**: `DeselectTeam` called `removeTeamFromAll`, which stripped the team from every `RoundSelections` field
- **Fix**: `DeselectTeam` now carries the `SelectionRound` where the click occurred, and uses `removeTeamFromRoundAndAbove` to only clear the team from the target round and all higher rounds (toward champion), preserving feeder rounds below

## Test plan
- [ ] Select teams through R32 → R16 → QF
- [ ] Deselect a team in R16 — verify it disappears from R16 but remains in R32 pool and can be re-selected
- [ ] Deselect a team in QF — verify it remains in R16 and R32
- [ ] Deselect a team in R32 — verify it's removed from all rounds (cascade up)
- [ ] Complete full bracket and verify submit still works

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)