### PR TITLE
fix: enforce minimum 2 teams per group in R32 bracket

### DIFF
--- a/src/Form/Bracket/Types.elm
+++ b/src/Form/Bracket/Types.elm
@@ -21,6 +21,7 @@ module Form.Bracket.Types exposing
     )
 
 import Bets.Types exposing (Group, Team, TeamData)
+import Bets.Types.Group as Group
 import List.Extra
 import UI.Screen as Screen
 
@@ -269,7 +270,6 @@ canSelectTeam round team sel teamData =
         poolOk =
             case round of
                 LastThirtyTwoRound ->
-                    -- Group cap: at most 3 teams from the same group in lastThirtyTwo
                     let
                         teamGroup =
                             List.head (List.filter (\td -> td.team.teamID == team.teamID) teamData)
@@ -277,7 +277,18 @@ canSelectTeam round team sel teamData =
                     in
                     case teamGroup of
                         Just grp ->
-                            countGroupInList grp sel.lastThirtyTwo teamData < 3
+                            let
+                                groupCount =
+                                    countGroupInList grp sel.lastThirtyTwo teamData
+                            in
+                            if groupCount >= 3 then
+                                False
+
+                            else if groupCount == 2 then
+                                countGroupsWithThree sel.lastThirtyTwo teamData < maxGroupsWithThree teamData
+
+                            else
+                                True
 
                         Nothing ->
                             True
@@ -298,6 +309,28 @@ canSelectTeam round team sel teamData =
                     List.any (\t -> t.teamID == team.teamID) sel.finalists
     in
     hasCapacity && notAlreadyInRound && poolOk
+
+
+maxGroupsWithThree : TeamData -> Int
+maxGroupsWithThree teamData =
+    let
+        numGroups =
+            List.map .group teamData
+                |> List.Extra.uniqueBy Group.toString
+                |> List.length
+    in
+    roundRequired LastThirtyTwoRound - numGroups * 2
+
+
+countGroupsWithThree : List Team -> TeamData -> Int
+countGroupsWithThree teams teamData =
+    let
+        allGroups =
+            List.map .group teamData
+                |> List.Extra.uniqueBy Group.toString
+    in
+    List.filter (\grp -> countGroupInList grp teams teamData >= 3) allGroups
+        |> List.length
 
 
 isWizardComplete : RoundSelections -> Bool


### PR DESCRIPTION
## Summary
- When 8 groups already have 3 teams selected in the round of 32, remaining groups with 2 teams are locked — their unselected members become unselectable
- This guarantees every group contributes at least 2 teams (since 8×3 + 4×2 = 32)
- Adds `maxGroupsWithThree` and `countGroupsWithThree` helpers to `Form.Bracket.Types`

Fixes #101

## Test plan
- [ ] Select 3 teams from 8 different groups — verify that 3rd team in remaining groups becomes greyed out/unselectable
- [ ] Verify you can still select 2nd team from groups that only have 1
- [ ] Complete full bracket wizard flow and submit successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)