### PR TITLE
feat: add Chat display header to home page

### DIFF
--- a/src/View.elm
+++ b/src/View.elm
@@ -639,7 +639,8 @@ viewHome model =
         , Element.width Element.fill
         , Screen.className "hallo"
         ]
-        [ Activities.viewCommentInput model.activities
+        [ UI.Text.displayHeader "Chat"
+        , Activities.viewCommentInput model.activities
         , Activities.view model
         ]
 


### PR DESCRIPTION
## Summary
- Adds a `displayHeader "Chat"` at the top of the home page, above the comment input and activity feed
- Consistent with the display header pattern used across all other pages

## Test plan
- [ ] Navigate to the home page and verify the "Chat" header appears above the comment input

🤖 Generated with [Claude Code](https://claude.com/claude-code)