### PR TITLE
Polish UI away from terminal theme

### DIFF
--- a/src/Form/Bracket/View.elm
+++ b/src/Form/Bracket/View.elm
@@ -24,7 +24,6 @@ import Form.Bracket.Types
         , roundRequired
         , roundTeams
         )
-import UI.Button
 import UI.Page exposing (page)
 import UI.Style
 import UI.Text
@@ -67,46 +66,12 @@ view _ state =
                 , UI.Text.bulletText "13 punten voor de kampioen. "
                 ]
 
-        isCurrentRoundComplete =
-            List.length (roundTeams activeRound sel) >= roundRequired activeRound
-
-        backButton =
-            if activeRound == LastThirtyTwoRound then
-                Element.none
-
-            else
-                Element.el
-                    [ Element.Events.onClick GoPrev
-                    , Element.pointer
-                    , Font.color Color.orange
-                    , UI.Font.mono
-                    , Font.size UI.Font.bodySize
-                    , Element.mouseOver [ Font.color Color.activeNav ]
-                    ]
-                    (Element.text "< vorige")
-
-        forwardButton =
-            if isCurrentRoundComplete then
-                UI.Button.pillSmall UI.Style.Focus GoNext "Ga verder \u{2192}"
-
-            else
-                Element.none
-
-        roundNav =
-            Element.row
-                [ Element.width Element.fill
-                , Element.paddingXY 0 8
-                ]
-                [ backButton
-                , Element.el [ Element.alignRight ] forwardButton
-                ]
     in
     page "bracket"
         [ UI.Text.displayHeader (roundTitle activeRound)
         , introduction
         , viewStepper activeRound sel
         , section
-        , roundNav
         , extroduction
         ]
 
@@ -362,7 +327,7 @@ viewSelectableTeam round sel teamData_ team =
                 , description = T.display team
                 }
 
-        innerRow cellColor =
+        innerRow cellColor subColor =
             Element.row
                 [ spacing 8
                 , Element.centerX
@@ -379,7 +344,7 @@ viewSelectableTeam round sel teamData_ team =
                         (Element.text (T.display team))
                     , Element.el
                         [ UI.Font.mono
-                        , Font.color Color.grey
+                        , Font.color subColor
                         , Font.size UI.Font.captionSize
                         ]
                         (Element.text (String.toLower (T.display team)))
@@ -399,7 +364,7 @@ viewSelectableTeam round sel teamData_ team =
             , Border.color Color.orange
             , paddingXY 12 10
             ]
-            (innerRow Color.orange)
+            (innerRow Color.orange Color.activeNav)
 
     else if canSelect then
         -- Grey border, hover to orange, tappable to select
@@ -415,7 +380,7 @@ viewSelectableTeam round sel teamData_ team =
             , paddingXY 12 10
             , Element.mouseOver [ Border.color Color.orange ]
             ]
-            (innerRow Color.primaryText)
+            (innerRow Color.primaryText Color.grey)
 
     else
         -- Grey border, grey text, not tappable
@@ -428,7 +393,7 @@ viewSelectableTeam round sel teamData_ team =
             , Border.color Color.terminalBorder
             , paddingXY 12 10
             ]
-            (innerRow Color.grey)
+            (innerRow Color.grey Color.grey)
 
 
 viewCompactBadge : SelectionRound -> RoundSelections -> TeamData -> Team -> Element Msg
@@ -450,7 +415,10 @@ viewCompactBadge round sel _ team =
                 }
 
         textColor =
-            if not canSelect then
+            if isInRound then
+                Color.orange
+
+            else if not canSelect then
                 Color.grey
 
             else
@@ -527,11 +495,21 @@ viewWideBadge maxWidth round sel _ team =
                 }
 
         nameColor =
-            if not canSelect then
+            if isInRound then
+                Color.orange
+
+            else if not canSelect then
                 Color.grey
 
             else
                 Color.primaryText
+
+        codeColor =
+            if isInRound then
+                Color.activeNav
+
+            else
+                Color.grey
 
         content =
             Element.row
@@ -552,7 +530,7 @@ viewWideBadge maxWidth round sel _ team =
                         [ Element.text (T.displayFull team) ]
                     , Element.el
                         [ UI.Font.mono
-                        , Font.color Color.grey
+                        , Font.color codeColor
                         , Font.size UI.Font.captionSize
                         ]
                         (Element.text (String.toLower (T.display team)))

--- a/src/UI/Color.elm
+++ b/src/UI/Color.elm
@@ -102,7 +102,7 @@ amber =
 
 grey : Color
 grey =
-    rgb255 0x55 0x55 0x55
+    rgb255 0x88 0x88 0x88
 
 
 shadow : Color
@@ -216,12 +216,12 @@ terminalAccentDim =
 
 inactiveNav : Color
 inactiveNav =
-    rgb255 0x7A 0x7A 0x70
+    rgb255 0x9A 0x9A 0x90
 
 
 dimText : Color
 dimText =
-    rgb255 0x44 0x44 0x44
+    rgb255 0x66 0x66 0x66
 
 
 mutedText : Color

--- a/src/UI/Style.elm
+++ b/src/UI/Style.elm
@@ -304,13 +304,13 @@ buttonActive =
     [ Background.color Color.amber
     , paddingXY 20 8
     , Font.size (scaled 2)
-    , Border.rounded 0
+    , Border.rounded 4
     , Font.color Color.primary
     , Border.width 1
     , Border.color Color.amber
     , Element.pointer
     , Element.mouseOver
-        [ Background.color Color.amber
+        [ Background.color Color.orange
         , Font.color Color.primary
         ]
     , UI.Font.button
@@ -324,7 +324,7 @@ buttonInactive =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 0
+    , Border.rounded 4
     , Font.color Color.grey
     , Border.width 1
     , Border.color Color.terminalBorder
@@ -341,7 +341,7 @@ buttonWrong =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 0
+    , Border.rounded 4
     , Border.width 1
     , Element.pointer
     , UI.Font.button
@@ -356,7 +356,7 @@ buttonRight =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 0
+    , Border.rounded 4
     , Border.width 1
     , Element.pointer
     , UI.Font.button
@@ -371,7 +371,7 @@ buttonPerhaps =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 0
+    , Border.rounded 4
     , Border.width 1
     , Border.color Color.terminalBorder
     , Element.pointer
@@ -388,7 +388,7 @@ buttonIrrelevant =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 0
+    , Border.rounded 4
     , Element.pointer
     , UI.Font.button
     , Element.centerY
@@ -402,7 +402,7 @@ buttonPotential =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 0
+    , Border.rounded 4
     , Border.width 1
     , Border.color Color.terminalBorder
     , Element.pointer
@@ -422,7 +422,7 @@ buttonSelected =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 0
+    , Border.rounded 4
     , Border.width 1
     , Border.color Color.orange
     , Element.pointer
@@ -439,9 +439,10 @@ buttonFocus =
     , paddingXY 20 5
     , Element.height (px 34)
     , Font.size (scaled 2)
-    , Border.rounded 0
+    , Border.rounded 4
     , Element.mouseOver
-        [ Font.color Color.primary
+        [ Background.color Color.orange
+        , Font.color Color.primary
         ]
     , Border.color Color.amber
     , Element.pointer
@@ -474,7 +475,7 @@ scoreButtonSBSelected =
     , paddingXY 15 5
     , Element.height (px 34)
     , Font.size (scaled 1)
-    , Border.rounded 0
+    , Border.rounded 4
     , Border.width 0
     , Element.spacing 10
     , Font.center
@@ -757,13 +758,14 @@ buttonPill : List (Element.Attribute msg)
 buttonPill =
     [ Background.color Color.panel
     , Font.color Color.primaryText
-    , Border.rounded 0
+    , Border.rounded 4
     , Border.width 1
     , Border.color Color.terminalBorder
     , paddingXY 20 5
     , Element.pointer
     , Element.mouseOver
         [ Font.color Color.orange
+        , Border.color Color.orange
         ]
     , UI.Font.button
     , Element.centerY
@@ -774,7 +776,7 @@ buttonPillA : List (Element.Attribute msg)
 buttonPillA =
     [ Background.color Color.panel
     , Font.color Color.orange
-    , Border.rounded 0
+    , Border.rounded 4
     , Border.color Color.orange
     , paddingXY 20 5
     , Border.width 1
@@ -788,11 +790,14 @@ buttonPillB : List (Element.Attribute msg)
 buttonPillB =
     [ Background.color Color.orange
     , Font.color Color.primary
-    , Border.rounded 0
+    , Border.rounded 4
     , paddingXY 20 5
     , Border.color Color.orange
     , Border.width 1
     , Element.pointer
+    , Element.mouseOver
+        [ Background.color Color.amber
+        ]
     , UI.Font.button
     , Element.centerY
     ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -430,11 +430,9 @@ viewFormNavBar model =
     case model.app of
         Form ->
             let
-                isFirst =
-                    model.idx == 0
-
-                isLast =
-                    model.idx == List.length model.cards - 1
+                currentCard =
+                    List.drop model.idx model.cards
+                        |> List.head
 
                 prev =
                     Basics.max (model.idx - 1) 0
@@ -442,7 +440,71 @@ viewFormNavBar model =
                 next =
                     Basics.min (model.idx + 1) (List.length model.cards - 1)
 
-                prevButton =
+                -- Determine bracket round context (if on a bracket card)
+                bracketRound =
+                    case currentCard of
+                        Just (BracketCard bs) ->
+                            let
+                                (BracketTypes.BracketWizard ws) =
+                                    bs.bracketState
+                            in
+                            Just ws.currentPage
+
+                        _ ->
+                            Nothing
+
+                -- Prev action: bracket-aware
+                prevMsg =
+                    case bracketRound of
+                        Just BracketTypes.LastThirtyTwoRound ->
+                            -- At first bracket round, go to prev card
+                            if model.idx == 0 then
+                                Nothing
+
+                            else
+                                Just (NavigateTo prev)
+
+                        Just _ ->
+                            Just (BracketMsg BracketTypes.GoPrev)
+
+                        Nothing ->
+                            if model.idx == 0 then
+                                Nothing
+
+                            else
+                                Just (NavigateTo prev)
+
+                -- Next action: bracket-aware
+                nextMsg =
+                    case bracketRound of
+                        Just BracketTypes.ChampionRound ->
+                            -- At last bracket round, go to next card
+                            if model.idx == List.length model.cards - 1 then
+                                Nothing
+
+                            else
+                                Just (NavigateTo next)
+
+                        Just _ ->
+                            Just (BracketMsg BracketTypes.GoNext)
+
+                        Nothing ->
+                            if model.idx == List.length model.cards - 1 then
+                                Nothing
+
+                            else
+                                Just (NavigateTo next)
+
+                -- Center label: show bracket round name when in bracket
+                centerLabel =
+                    case bracketRound of
+                        Just round ->
+                            bracketRoundLabel round
+
+                        Nothing ->
+                            cardLabel model
+
+                disabledButton label =
                     Element.el
                         [ Element.height (Element.px 50)
                         , Element.centerY
@@ -450,44 +512,36 @@ viewFormNavBar model =
                         , UI.Font.mono
                         , Font.size UI.Font.bodySize
                         ]
-                        (UI.Text.allCenteredText "< vorige")
+                        (UI.Text.allCenteredText label)
+
+                activeButton msg label =
+                    Element.el
+                        [ Element.Events.onClick msg
+                        , Element.pointer
+                        , Element.height (Element.px 50)
+                        , Element.centerY
+                        , Font.color Color.orange
+                        , UI.Font.mono
+                        , Font.size UI.Font.bodySize
+                        , Element.mouseOver [ Font.color Color.white ]
+                        ]
+                        (UI.Text.allCenteredText label)
+
+                prevButton =
+                    case prevMsg of
+                        Just msg ->
+                            activeButton msg "\u{2190} vorige"
+
+                        Nothing ->
+                            disabledButton "\u{2190} vorige"
 
                 nextButton =
-                    Element.el
-                        [ Element.height (Element.px 50)
-                        , Element.centerY
-                        , Font.color Color.mutedText
-                        , UI.Font.mono
-                        , Font.size UI.Font.bodySize
-                        ]
-                        (UI.Text.allCenteredText "volgende >")
+                    case nextMsg of
+                        Just msg ->
+                            activeButton msg "volgende \u{2192}"
 
-                activePrevButton =
-                    Element.el
-                        [ Element.Events.onClick (NavigateTo prev)
-                        , Element.pointer
-                        , Element.height (Element.px 50)
-                        , Element.centerY
-                        , Font.color Color.orange
-                        , UI.Font.mono
-                        , Font.size UI.Font.bodySize
-                        , Element.mouseOver [ Font.color Color.white ]
-                        ]
-                        (UI.Text.allCenteredText "< vorige")
-
-                activeNextButton =
-                    Element.el
-                        [ Element.Events.onClick (NavigateTo next)
-                        , Element.pointer
-                        , Element.height (Element.px 50)
-                        , Element.centerY
-                        , Font.color Color.orange
-                        , UI.Font.mono
-                        , Font.size UI.Font.bodySize
-                        , Element.mouseOver [ Font.color Color.white ]
-                        ]
-                        (UI.Text.allCenteredText "volgende >")
-
+                        Nothing ->
+                            disabledButton "volgende \u{2192}"
             in
             Element.row
                 [ Element.width Element.fill
@@ -502,14 +556,14 @@ viewFormNavBar model =
                     , Element.height (Element.px 50)
                     , Element.centerY
                     ]
-                    (if isFirst then prevButton else activePrevButton)
+                    prevButton
                 , Element.el
                     [ Element.width (Element.fillPortion 2)
                     , Element.centerX
                     , UI.Font.mono
                     ]
                     (Element.row [ Element.centerX, Element.centerY, Element.spacing 6 ]
-                        [ Element.el [ Font.color Color.activeNav, Font.size UI.Font.bodySize ] (Element.text (cardLabel model))
+                        [ Element.el [ Font.color Color.activeNav, Font.size UI.Font.bodySize ] (Element.text centerLabel)
                         , Element.el [ Font.color Color.grey, Font.size UI.Font.captionSize ] (Element.text ("· " ++ cardStatusSuffix model))
                         ]
                     )
@@ -519,11 +573,33 @@ viewFormNavBar model =
                     , Element.centerY
                     , Element.alignRight
                     ]
-                    (if isLast then nextButton else activeNextButton)
+                    nextButton
                 ]
 
         _ ->
             Element.none
+
+
+bracketRoundLabel : BracketTypes.SelectionRound -> String
+bracketRoundLabel round =
+    case round of
+        BracketTypes.ChampionRound ->
+            "kampioen"
+
+        BracketTypes.FinalistRound ->
+            "finale"
+
+        BracketTypes.SemiRound ->
+            "halve finale"
+
+        BracketTypes.QuarterRound ->
+            "kwartfinale"
+
+        BracketTypes.LastSixteenRound ->
+            "ronde van 16"
+
+        BracketTypes.LastThirtyTwoRound ->
+            "ronde van 32"
 
 
 viewStatusBar : Model Msg -> Element.Element Msg


### PR DESCRIPTION
## Summary
- **Contrast bump**: Increased `grey`, `dimText`, and `inactiveNav` color values for better readability on dark backgrounds
- **Button polish**: Added `Border.rounded 4` to all button styles and improved hover states (replacing sharp terminal-style corners)
- **Selected teams stay bright**: Bracket teams selected for a round now show orange name text and bright code text instead of inheriting dimmed grey
- **Merged navigation**: Removed bracket's own vorige/volgende buttons; the bottom nav bar now steps through bracket rounds directly, with the center label showing the current round name

## Test plan
- [ ] Navigate through the bracket wizard — bottom bar should step through R32 → R16 → KF → HF → F → Kampioen
- [ ] At R32, "← vorige" goes to the previous card (groepen); at Kampioen, "volgende →" goes to the next card (topscorer)
- [ ] Selected teams in bracket show bright orange text, not dimmed
- [ ] Non-selectable teams are grey but readable (not too dim)
- [ ] Buttons throughout the app have subtle rounding
- [ ] Progress rail labels and inactive nav items are readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)