### PR TITLE
feat: polish text input fields away from terminal aesthetic

### DIFF
--- a/src/Activities.elm
+++ b/src/Activities.elm
@@ -175,18 +175,15 @@ viewCommentInput model =
                     , spellcheck = True
                     }
             in
-            Element.row [ spacing 8, width fill ]
-                [ Element.el [ Font.color Color.orange, UI.Font.mono, Element.alignTop, Element.paddingXY 0 8 ] (Element.text ">")
-                , Input.multiline
-                    (UI.Style.terminalInput False
-                        [ height (px 120)
-                        , width fill
-                        , Font.size UI.Font.bodySize
-                        , Element.htmlAttribute (Html.Attributes.id "comment-input")
-                        ]
-                    )
-                    area
-                ]
+            Input.multiline
+                (UI.Style.textInput False
+                    [ height (px 120)
+                    , width fill
+                    , Font.size UI.Font.bodySize
+                    , Element.htmlAttribute (Html.Attributes.id "comment-input")
+                    ]
+                )
+                area
 
         commentInputTrap =
             let
@@ -197,18 +194,15 @@ viewCommentInput model =
                     , placeholder = Nothing
                     }
             in
-            Element.row [ spacing 8, width fill ]
-                [ Element.el [ Font.color Color.orange, UI.Font.mono, Element.centerY ] (Element.text ">")
-                , Input.text
-                    (UI.Style.terminalInput False
-                        [ Events.onFocus ShowCommentInput
-                        , height (px 48)
-                        , width fill
-                        , Font.size UI.Font.bodySize
-                        ]
-                    )
-                    area
-                ]
+            Input.text
+                (UI.Style.textInput False
+                    [ Events.onFocus ShowCommentInput
+                    , height (px 48)
+                    , width fill
+                    , Font.size UI.Font.bodySize
+                    ]
+                )
+                area
 
         authorInput v =
             let
@@ -219,17 +213,14 @@ viewCommentInput model =
                     , placeholder = Nothing
                     }
             in
-            Element.row [ spacing 8, width fill ]
-                [ Element.el [ Font.color Color.orange, UI.Font.mono, Element.centerY ] (Element.text ">")
-                , Input.text
-                    (UI.Style.terminalInput False
-                        [ height (px 48)
-                        , width fill
-                        , Font.size UI.Font.bodySize
-                        ]
-                    )
-                    area
-                ]
+            Input.text
+                (UI.Style.textInput False
+                    [ height (px 48)
+                    , width fill
+                    , Font.size UI.Font.bodySize
+                    ]
+                )
+                area
 
         saveButton =
             if (model.comment.msg == "") || (model.comment.author == "") then
@@ -270,7 +261,7 @@ viewPostInput model =
                     , label = UI.Text.labelText "titel"
                     }
             in
-            Input.text (UI.Style.terminalInput False [ height (px 36), width fill, Font.size UI.Font.bodySize ]) area
+            Input.text (UI.Style.textInput False [ height (px 36), width fill, Font.size UI.Font.bodySize ]) area
 
         postInput v =
             let
@@ -282,7 +273,7 @@ viewPostInput model =
                     , spellcheck = True
                     }
             in
-            Input.multiline (UI.Style.terminalInput False [ height (px 200), width fill, Font.size UI.Font.bodySize, Element.htmlAttribute (Html.Attributes.id "post-input") ]) area
+            Input.multiline (UI.Style.textInput False [ height (px 200), width fill, Font.size UI.Font.bodySize, Element.htmlAttribute (Html.Attributes.id "post-input") ]) area
 
         postInputTrap =
             let
@@ -293,7 +284,7 @@ viewPostInput model =
                     , placeholder = Nothing
                     }
             in
-            Input.text (UI.Style.terminalInput False [ Events.onFocus ShowPostInput, height (px 36), width fill, Font.size UI.Font.bodySize ]) area
+            Input.text (UI.Style.textInput False [ Events.onFocus ShowPostInput, height (px 36), width fill, Font.size UI.Font.bodySize ]) area
 
         passphraseInput v =
             let
@@ -304,7 +295,7 @@ viewPostInput model =
                     , placeholder = Nothing
                     }
             in
-            Input.text (UI.Style.terminalInput False [ height (px 36), width fill, Font.size UI.Font.bodySize ]) area
+            Input.text (UI.Style.textInput False [ height (px 36), width fill, Font.size UI.Font.bodySize ]) area
 
         authorInput v =
             let
@@ -315,7 +306,7 @@ viewPostInput model =
                     , placeholder = Nothing
                     }
             in
-            Input.text (UI.Style.terminalInput False [ height (px 36), width fill, Font.size UI.Font.bodySize ]) area
+            Input.text (UI.Style.textInput False [ height (px 36), width fill, Font.size UI.Font.bodySize ]) area
 
         saveButton =
             if (model.post.msg == "") || (model.post.author == "") || (model.post.passphrase == "") then

--- a/src/Authentication.elm
+++ b/src/Authentication.elm
@@ -1,7 +1,6 @@
 module Authentication exposing (..)
 
 import Element exposing (fill, height, padding, px, spacing, width)
-import Element.Events as Events
 import Element.Input as Input
 import Json.Decode exposing (Decoder, field)
 import Json.Encode
@@ -32,10 +31,9 @@ view model =
                     , text = v
                     , placeholder = Nothing
                     , label = UI.Text.labelText "username"
-                    , spellcheck = True
                     }
             in
-            Input.multiline (UI.Style.terminalInput False [ Events.onFocus ShowCommentInput, height (px 48), width fill ]) area
+            Input.text (UI.Style.textInput False [ height (px 48), width fill ]) area
 
         password v =
             let
@@ -46,7 +44,7 @@ view model =
                     , label = UI.Text.labelText "password"
                     }
             in
-            Input.text (UI.Style.terminalInput False [ height (px 48), width fill ]) area
+            Input.text (UI.Style.textInput False [ height (px 48), width fill ]) area
 
         loginButton isSubmittable_ =
             if isSubmittable_ then

--- a/src/Form/Participant.elm
+++ b/src/Form/Participant.elm
@@ -7,10 +7,7 @@ module Form.Participant exposing
 import Bets.Bet exposing (setParticipant)
 import Bets.Types exposing (Bet, StringField(..))
 import Bets.Types.Participant
-import Bets.Types.StringField as StringField
-import Element exposing (centerX, fill, height, paddingEach, paddingXY, px, spacing, width)
-import Element.Background as Background
-import Element.Border as Border
+import Element exposing (fill, spacing, width)
 import Element.Font as Font
 import Element.Input
 import Email
@@ -20,7 +17,6 @@ import Html.Events
 import UI.Color as Color
 import UI.Font
 import UI.Page exposing (page)
-import UI.Screen as Screen
 import UI.Style
 import UI.Text
 
@@ -82,7 +78,7 @@ update msg state bet =
 
 
 view : State -> Bet -> Element.Element Msg
-view state bet =
+view _ bet =
     let
         keys =
             [ Name, Postal, Residence, Email, Phone, Knows ]
@@ -112,39 +108,6 @@ view state bet =
                         Error s ->
                             ( s, True )
 
-                isActive =
-                    state.activeField == Just tag
-
-                borderColor =
-                    if hasError then
-                        Color.red
-
-                    else if isActive then
-                        Color.orange
-
-                    else
-                        Color.terminalBorder
-
-                promptChar =
-                    if hasError then
-                        "!"
-
-                    else if isActive then
-                        ">"
-
-                    else
-                        "-"
-
-                promptColor =
-                    if hasError then
-                        Color.red
-
-                    else if isActive then
-                        Color.orange
-
-                    else
-                        Color.grey
-
                 inp =
                     { onChange = \val -> Set (k val)
                     , text = stringVal
@@ -160,43 +123,25 @@ view state bet =
                         , UI.Font.mono
                         ]
                         (Element.text (String.toUpper lbl))
-
-                borderedContainer =
-                    Element.row
-                        [ Border.width 1
-                        , Border.color borderColor
-                        , Element.padding 8
-                        , width fill
-                        , Element.spacing 8
-                        , Background.color Color.black
-                        ]
-                        [ Element.el
-                            [ Font.color promptColor
-                            , UI.Font.mono
-                            , Element.width (px 12)
-                            ]
-                            (Element.text promptChar)
-                        , Element.Input.text
-                            (UI.Style.terminalInput hasError
-                                ([ width fill
-                                 , Font.size UI.Font.bodySize
-                                 , Element.htmlAttribute (Html.Events.onFocus (FocusField tag))
-                                 , Element.htmlAttribute (Html.Events.onBlur BlurField)
-                                 ]
-                                    ++ (if tag == NameTag then
-                                            [ Element.htmlAttribute (Html.Attributes.id "participant-name") ]
-
-                                        else
-                                            []
-                                       )
-                                )
-                            )
-                            inp
-                        ]
             in
             Element.column [ Element.spacing 4, width fill ]
                 [ labelEl
-                , borderedContainer
+                , Element.Input.text
+                    (UI.Style.textInput hasError
+                        ([ width fill
+                         , Font.size UI.Font.bodySize
+                         , Element.htmlAttribute (Html.Events.onFocus (FocusField tag))
+                         , Element.htmlAttribute (Html.Events.onBlur BlurField)
+                         ]
+                            ++ (if tag == NameTag then
+                                    [ Element.htmlAttribute (Html.Attributes.id "participant-name") ]
+
+                                else
+                                    []
+                               )
+                        )
+                    )
+                    inp
                 ]
 
         lines =

--- a/src/Form/Topscorer.elm
+++ b/src/Form/Topscorer.elm
@@ -11,8 +11,8 @@ import Element.Background as Background
 import Element.Border as Border
 import Element.Events
 import Element.Font as Font
+import Element.Input
 import Form.Topscorer.Types exposing (IsSelected(..), Msg(..))
-import Html
 import Html.Attributes
 import Html.Events
 import UI.Color as Color
@@ -236,45 +236,21 @@ viewPlayerCard topscorer entry =
 
 
 viewSearchInput : String -> Bool -> Element.Element Msg
-viewSearchInput query focused =
-    let
-        containerBorderColor =
-            if focused then
-                Color.activeNav
-
-            else
-                Color.terminalBorder
-    in
-    Element.row
-        [ Element.spacing 0
-        , Element.paddingXY 8 6
-        , Element.width Element.fill
-        , Border.width 1
-        , Border.color containerBorderColor
-        ]
-        [ Element.el [ Font.color Color.orange, UI.Font.mono, Element.paddingXY 4 0 ]
-            (Element.text ">")
-        , Element.el [ Element.width Element.fill ]
-            (Element.html
-                (Html.input
-                    [ Html.Attributes.id "topscorer-search"
-                    , Html.Attributes.value query
-                    , Html.Attributes.placeholder "zoek op naam of land..."
-                    , Html.Events.onInput UpdateSearch
-                    , Html.Events.onFocus (SearchFocused True)
-                    , Html.Events.onBlur (SearchFocused False)
-                    , Html.Attributes.style "background" "transparent"
-                    , Html.Attributes.style "border" "none"
-                    , Html.Attributes.style "color" "#dcdccc"
-                    , Html.Attributes.style "font-family" "inherit"
-                    , Html.Attributes.style "outline" "none"
-                    , Html.Attributes.style "width" "100%"
-                    , Html.Attributes.style "padding" "2px 4px"
-                    ]
-                    []
-                )
-            )
-        ]
+viewSearchInput query _ =
+    Element.Input.text
+        (UI.Style.textInput False
+            [ Element.width Element.fill
+            , Font.size UI.Font.bodySize
+            , Element.htmlAttribute (Html.Attributes.id "topscorer-search")
+            , Element.htmlAttribute (Html.Events.onFocus (SearchFocused True))
+            , Element.htmlAttribute (Html.Events.onBlur (SearchFocused False))
+            ]
+        )
+        { onChange = UpdateSearch
+        , text = query
+        , label = Element.Input.labelHidden "zoek speler"
+        , placeholder = Just (Element.Input.placeholder [ Font.color Color.grey, UI.Font.mono ] (Element.text "zoek op naam of land..."))
+        }
 
 
 viewEmptyState : String -> Element.Element Msg

--- a/src/UI/Style.elm
+++ b/src/UI/Style.elm
@@ -37,7 +37,6 @@ module UI.Style exposing
     , submitButtonActive
     , submitButtonInactive
     , submitButtonSuccess
-    , terminalInput
     , secondaryText
     , teamBadge
     , teamBadgeVerySmall
@@ -600,27 +599,6 @@ scoreInput attrs =
            ]
 
 
-terminalInput : Bool -> List (Element.Attribute msg) -> List (Element.Attribute msg)
-terminalInput hasError attrs =
-    let
-        borderColor =
-            if hasError then
-                Color.red
-
-            else
-                Color.terminalBorder
-    in
-    attrs
-        ++ [ Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
-           , Border.color borderColor
-           , Border.rounded 0
-           , Background.color Color.primaryDark
-           , Font.color Color.white
-           , UI.Font.input
-           , Element.paddingXY 4 8
-           , Element.focused [ Border.color Color.orange ]
-           ]
-
 
 score : List (Element.Attribute msg) -> List (Element.Attribute msg)
 score attrs =
@@ -819,12 +797,17 @@ textInput hasError attrs =
                 Color.terminalBorder
     in
     attrs
-        ++ [ Border.width 1
+        ++ [ Border.widthEach { bottom = 1, top = 0, left = 0, right = 0 }
            , Border.rounded 0
            , Border.color borderColor
-           , Font.color Color.primaryDark
+           , Background.color Color.primaryDark
+           , Font.color Color.white
            , UI.Font.input
-           , Element.height (px 50)
+           , Element.paddingXY 4 8
+           , Element.focused
+                [ Border.color Color.orange
+                , Border.shadow { offset = ( 0, 0 ), size = 0, blur = 12, color = Color.orangeOverlay08 }
+                ]
            ]
 
 


### PR DESCRIPTION
## Summary
- Replace terminal-style text inputs (underline-only with `>` / `-` / `!` prompt prefixes) with clean underline inputs featuring subtle orange focus glow
- Apply consistently across participant form, topscorer search, activities comments/posts, and login page
- Fix pre-existing bug where login username used `Input.multiline` with unrelated `ShowCommentInput` handler

## Test plan
- [ ] Verify participant form fields render without prompt characters and with underline style
- [ ] Verify topscorer search input works (type, filter, focus/blur)
- [ ] Verify activities comment and blog post inputs render cleanly
- [ ] Verify login page username/password fields work correctly
- [ ] Verify orange glow appears on focus for all text inputs
- [ ] Verify error state (red border) still works on participant fields

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)