### PR TITLE
fix: batch of small UI enhancements

### DIFF
--- a/src/Activities.elm
+++ b/src/Activities.elm
@@ -115,7 +115,7 @@ blogBox author title blog tz dt =
         ]
         [ row [ paddingXY 12 8, Element.spacing 8 ]
             [ Element.el [ Font.color Color.grey, Font.size UI.Font.bodySize, UI.Font.mono ] (Element.text (UI.Text.timeText tz dt))
-            , Element.el [ Font.color Color.orange, UI.Font.mono ] (Element.text ("## " ++ title))
+            , Element.el [ Font.color Color.orange, UI.Font.mono, Font.size UI.Font.bodySize ] (Element.text ("## " ++ title))
             ]
         , Element.el [ paddingXY 12 8, width fill ] (blogView blog)
         , Element.el [ alignRight, paddingXY 12 8, Font.color Color.grey, Font.size UI.Font.bodySize, UI.Font.mono ]
@@ -135,7 +135,7 @@ commentBox author comment tz dt =
         ]
         [ row [ paddingXY 12 8, Element.spacing 8 ]
             [ Element.el [ Font.color Color.grey, Font.size UI.Font.bodySize, UI.Font.mono ] (Element.text (UI.Text.timeText tz dt))
-            , Element.el [ Font.color Color.orange, UI.Font.mono ] (Element.text (author ++ ":"))
+            , Element.el [ Font.color Color.orange, UI.Font.mono, Font.size UI.Font.bodySize ] (Element.text (author ++ ":"))
             ]
         , Element.el [ paddingXY 12 8, width fill ] (commentView comment)
         ]

--- a/src/Form/Bracket/View.elm
+++ b/src/Form/Bracket/View.elm
@@ -58,7 +58,7 @@ view _ state =
             viewRoundSection activeRound sel allGroups teamData_ dev (round state.screen.width)
 
         extroduction =
-            Element.column (UI.Style.introduction [ spacing 16 ])
+            Element.column (UI.Style.introduction [ spacing 16, Element.width Element.fill ])
                 [ UI.Text.bulletText "1 punt voor ieder juist land in de tweede ronde. "
                 , UI.Text.bulletText "4 punten per kwartfinalist. "
                 , UI.Text.bulletText "7 punten per halve finalist. "

--- a/src/Form/Participant.elm
+++ b/src/Form/Participant.elm
@@ -155,8 +155,8 @@ view _ bet =
             UI.Text.displayHeader "Wie ben jij"
 
         introduction =
-            Element.paragraph (UI.Style.introduction [ width fill, spacing 7 ])
-                [ UI.Text.simpleText """Graag volledig invullen, zodat wij je goed kunnen bereiken als je gewonnen hebt."""
+            Element.paragraph (UI.Style.introduction [])
+                [ Element.text "Graag volledig invullen, zodat wij je goed kunnen bereiken als je gewonnen hebt."
                 ]
     in
     page "participant"

--- a/src/Form/Topscorer.elm
+++ b/src/Form/Topscorer.elm
@@ -17,6 +17,7 @@ import Html.Attributes
 import Html.Events
 import UI.Color as Color
 import UI.Font
+import UI.Icon
 import UI.Page exposing (page)
 import UI.Style
 import UI.Text
@@ -190,11 +191,9 @@ viewPlayerCard topscorer entry =
         marker =
             if isSelected then
                 Element.el
-                    [ Font.color Color.activeNav
-                    , UI.Font.mono
-                    , Element.alignRight
+                    [ Element.alignRight
                     ]
-                    (Element.text "[x]")
+                    (UI.Icon.close 12 Color.activeNav)
 
             else
                 Element.none

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -1,0 +1,61 @@
+module UI.Icon exposing (close, hamburger)
+
+import Element
+import Svg
+import Svg.Attributes as SvgA
+
+
+hamburger : Int -> Element.Color -> Element.Element msg
+hamburger size color =
+    let
+        colorStr =
+            colorToString color
+    in
+    Element.html
+        (Svg.svg
+            [ SvgA.width (String.fromInt size)
+            , SvgA.height (String.fromInt size)
+            , SvgA.viewBox "0 0 16 16"
+            , SvgA.fill "none"
+            ]
+            [ Svg.line [ SvgA.x1 "2", SvgA.y1 "4", SvgA.x2 "14", SvgA.y2 "4", SvgA.stroke colorStr, SvgA.strokeWidth "1.5", SvgA.strokeLinecap "round" ] []
+            , Svg.line [ SvgA.x1 "2", SvgA.y1 "8", SvgA.x2 "14", SvgA.y2 "8", SvgA.stroke colorStr, SvgA.strokeWidth "1.5", SvgA.strokeLinecap "round" ] []
+            , Svg.line [ SvgA.x1 "2", SvgA.y1 "12", SvgA.x2 "14", SvgA.y2 "12", SvgA.stroke colorStr, SvgA.strokeWidth "1.5", SvgA.strokeLinecap "round" ] []
+            ]
+        )
+
+
+close : Int -> Element.Color -> Element.Element msg
+close size color =
+    let
+        colorStr =
+            colorToString color
+    in
+    Element.html
+        (Svg.svg
+            [ SvgA.width (String.fromInt size)
+            , SvgA.height (String.fromInt size)
+            , SvgA.viewBox "0 0 16 16"
+            , SvgA.fill "none"
+            ]
+            [ Svg.line [ SvgA.x1 "3", SvgA.y1 "3", SvgA.x2 "13", SvgA.y2 "13", SvgA.stroke colorStr, SvgA.strokeWidth "1.5", SvgA.strokeLinecap "round" ] []
+            , Svg.line [ SvgA.x1 "13", SvgA.y1 "3", SvgA.x2 "3", SvgA.y2 "13", SvgA.stroke colorStr, SvgA.strokeWidth "1.5", SvgA.strokeLinecap "round" ] []
+            ]
+        )
+
+
+colorToString : Element.Color -> String
+colorToString color =
+    let
+        { red, green, blue, alpha } =
+            Element.toRgb color
+    in
+    "rgba("
+        ++ String.fromInt (Basics.round (red * 255))
+        ++ ","
+        ++ String.fromInt (Basics.round (green * 255))
+        ++ ","
+        ++ String.fromInt (Basics.round (blue * 255))
+        ++ ","
+        ++ String.fromFloat alpha
+        ++ ")"

--- a/src/UI/Text.elm
+++ b/src/UI/Text.elm
@@ -85,7 +85,7 @@ bulletText txt =
                 (Element.el (Style.bullet [ alignLeft ]) (Element.text "•"))
 
         contents =
-            Element.paragraph (Style.introduction [ width Element.fill ]) [ Element.text txt ]
+            Element.paragraph [ width Element.fill ] [ Element.text txt ]
     in
     Element.row [ Element.paddingEach { top = 0, right = 0, bottom = 0, left = 5 }, spacing 16 ] [ bullet, contents ]
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -29,6 +29,7 @@ import Types exposing (App(..), Card(..), Credentials(..), DataStatus(..), Flags
 import UI.Button
 import UI.Color as Color
 import UI.Font
+import UI.Icon
 import UI.Screen as Screen
 import UI.Style
 import UI.Text
@@ -185,19 +186,13 @@ view model =
                 , Element.pointer
                 , Element.alignRight
                 , Element.centerY
-                , UI.Font.mono
-                , Font.color Color.inactiveNav
-                , Font.size (UI.Font.scaled 1)
                 , Element.paddingXY 8 0
-                , Element.mouseOver [ Font.color Color.orange ]
                 ]
-                (Element.text
-                    (if model.menuOpen then
-                        "[x]"
+                (if model.menuOpen then
+                    UI.Icon.close 20 Color.inactiveNav
 
-                     else
-                        "[=]"
-                    )
+                 else
+                    UI.Icon.hamburger 20 Color.inactiveNav
                 )
 
         mobileMenu =
@@ -285,7 +280,6 @@ view model =
                             [ Element.alignBottom, Element.width Element.fill ]
                             [ viewFormNavBar model
                             , viewInstallBanner model
-                            , viewStatusBar model
                             ]
                         )
                     ]
@@ -543,38 +537,43 @@ viewFormNavBar model =
                         Nothing ->
                             disabledButton "volgende \u{2192}"
             in
-            Element.row
+            Element.el
                 [ Element.width Element.fill
-                , Element.paddingXY 16 0
                 , Element.height (Element.px 50)
                 , Element.htmlAttribute (Html.Attributes.style "background" "linear-gradient(180deg, #12131a, #0f1017)")
                 , Border.widthEach { top = 1, bottom = 0, left = 0, right = 0 }
                 , Border.color Color.orangeOverlay08
                 ]
-                [ Element.el
-                    [ Element.width (Element.fillPortion 1)
-                    , Element.height (Element.px 50)
-                    , Element.centerY
-                    ]
-                    prevButton
-                , Element.el
-                    [ Element.width (Element.fillPortion 2)
+                (Element.row
+                    [ Element.width (Element.fill |> Element.maximum (Screen.maxWidth model.screen))
                     , Element.centerX
-                    , UI.Font.mono
-                    ]
-                    (Element.row [ Element.centerX, Element.centerY, Element.spacing 6 ]
-                        [ Element.el [ Font.color Color.activeNav, Font.size UI.Font.bodySize ] (Element.text centerLabel)
-                        , Element.el [ Font.color Color.grey, Font.size UI.Font.captionSize ] (Element.text ("· " ++ cardStatusSuffix model))
-                        ]
-                    )
-                , Element.el
-                    [ Element.width (Element.fillPortion 1)
+                    , Element.paddingXY 16 0
                     , Element.height (Element.px 50)
-                    , Element.centerY
-                    , Element.alignRight
                     ]
-                    nextButton
-                ]
+                    [ Element.el
+                        [ Element.width (Element.fillPortion 1)
+                        , Element.height (Element.px 50)
+                        , Element.centerY
+                        ]
+                        prevButton
+                    , Element.el
+                        [ Element.width (Element.fillPortion 2)
+                        , Element.centerX
+                        , UI.Font.mono
+                        ]
+                        (Element.row [ Element.centerX, Element.centerY, Element.spacing 6 ]
+                            [ Element.el [ Font.color Color.activeNav, Font.size UI.Font.bodySize ] (Element.text centerLabel)
+                            , Element.el [ Font.color Color.grey, Font.size UI.Font.captionSize ] (Element.text ("· " ++ cardStatusSuffix model))
+                            ]
+                        )
+                    , Element.el
+                        [ Element.width (Element.fillPortion 1)
+                        , Element.height (Element.px 50)
+                        , Element.centerY
+                        ]
+                        (Element.el [ Element.alignRight, Element.centerY ] nextButton)
+                    ]
+                )
 
         _ ->
             Element.none


### PR DESCRIPTION
## Summary
- Fix participant intro text font size to match other form pages
- Remove status bar (second footer) from form view
- Align footer vorige/volgende buttons to card max-width
- Replace topscorer `[x]` and hamburger menu text with SVG icons (new `UI.Icon` module)
- Fix bracket bullet list removing double-applied introduction style (orange border/dark bg)
- Fix bracket extroduction box width to match introduction width
- Fix home page blog title and comment author font sizes

Closes #123

## Test plan
- [ ] Check participant page intro text matches other pages' font size
- [ ] Verify only one footer bar appears at the bottom (no status bar)
- [ ] Verify vorige/volgende buttons align with card content width
- [ ] Check topscorer clear selection icon is a small SVG X
- [ ] Check hamburger menu shows SVG icons (open and closed states)
- [ ] Verify bracket page bullet items have no orange left border or dark background
- [ ] Verify bracket extroduction box is same width as introduction text
- [ ] Check home page blog titles and comment authors have correct (smaller) font size

🤖 Generated with [Claude Code](https://claude.com/claude-code)