### PR TITLE
add HTTP API test suite with dual mock/live modes

### DIFF
--- a/api-tests/.env.example
+++ b/api-tests/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env and fill in before running `make test-live`.
+# `make test` (mock mode) ignores these and uses its own defaults.
+
+# Base URL of the backend under test. No trailing slash.
+BASE_URL=https://your-backend.example.com
+
+# Credentials used by 01-auth.hurl to log in.
+TEST_USER=change-me
+TEST_PASS=change-me
+
+# Set to 1 to include mutating admin endpoints (writes match/topscorer/knockouts/ranking state).
+# Leave empty to skip them — useful when running against shared staging.
+RUN_MUTATING=

--- a/api-tests/.gitignore
+++ b/api-tests/.gitignore
@@ -1,0 +1,2 @@
+.env
+vars.generated.env

--- a/api-tests/Makefile
+++ b/api-tests/Makefile
@@ -1,0 +1,54 @@
+# API test suite runner.
+#
+# Targets:
+#   make test        -- start local mock, run all hurl tests against it, stop mock
+#   make test-live   -- run hurl tests against $BASE_URL from .env (real backend)
+#   make mock        -- run just the mock server in foreground (for debugging)
+
+SHELL := /bin/bash
+
+HURL_FILES := $(sort $(wildcard hurl/*.hurl))
+VARS_FILE  := vars.generated.env
+MOCK_PORT  ?= 8787
+MOCK_PID   := .mock.pid
+
+.PHONY: test test-live mock stop-mock clean _vars-mock _vars-live _run
+
+test: stop-mock _vars-mock
+	@node mock/server.mjs & echo $$! > $(MOCK_PID)
+	@sleep 0.3
+	@$(MAKE) --no-print-directory _run; rc=$$?; \
+	  $(MAKE) --no-print-directory stop-mock; \
+	  exit $$rc
+
+test-live: _vars-live _run
+
+mock:
+	@node mock/server.mjs
+
+stop-mock:
+	@if [ -f $(MOCK_PID) ]; then \
+	  kill $$(cat $(MOCK_PID)) 2>/dev/null || true; \
+	  rm -f $(MOCK_PID); \
+	fi
+
+clean: stop-mock
+	@rm -f $(VARS_FILE)
+
+_vars-mock:
+	@printf 'base_url=http://localhost:%s\ntest_user=mock\ntest_pass=mock\nskip_mutating=false\n' \
+	  "$(MOCK_PORT)" > $(VARS_FILE)
+
+_vars-live:
+	@if [ ! -f .env ]; then echo "error: .env not found (copy .env.example first)"; exit 2; fi
+	@set -a; . ./.env; set +a; \
+	  if [ -z "$$BASE_URL" ] || [ -z "$$TEST_USER" ] || [ -z "$$TEST_PASS" ]; then \
+	    echo "error: BASE_URL / TEST_USER / TEST_PASS must be set in .env"; exit 2; \
+	  fi; \
+	  skip="true"; if [ "$$RUN_MUTATING" = "1" ]; then skip="false"; fi; \
+	  printf 'base_url=%s\ntest_user=%s\ntest_pass=%s\nskip_mutating=%s\n' \
+	    "$$BASE_URL" "$$TEST_USER" "$$TEST_PASS" "$$skip" > $(VARS_FILE)
+
+_run:
+	@command -v hurl >/dev/null || { echo "error: hurl not installed (see api-tests/README.md)"; exit 127; }
+	hurl --test --file-root . --variables-file $(VARS_FILE) $(HURL_FILES)

--- a/api-tests/README.md
+++ b/api-tests/README.md
@@ -1,0 +1,79 @@
+# API tests
+
+HTTP contract tests for the Tournaments backend. Uses [Hurl](https://hurl.dev) as the test runner so the specs are plain `.hurl` files: readable, diffable, and runnable from CI.
+
+The same tests run in two modes:
+
+- **mock** (default) — a stateful Node mock server is started on `localhost:8787` and torn down at the end. Covers every endpoint the Elm client calls. Good for offline work and CI smoke tests.
+- **live** — runs against a real backend whose URL and credentials you set in `.env`.
+
+## Prerequisites
+
+- Node 18+ (uses built-in `http`; no npm deps)
+- Hurl 5+ (`pacman -S hurl` on Arch, `brew install hurl` on macOS, or see <https://hurl.dev/docs/installation.html>)
+- GNU make
+
+## Run against the mock
+
+```
+make test
+```
+
+The mock issues a fixed token, echoes bet UUIDs, validates `Authorization: Bearer` headers on protected routes, and 404s on unknown paths so missing endpoints fail loudly.
+
+## Run against a real backend
+
+```
+cp .env.example .env
+$EDITOR .env          # fill in BASE_URL, TEST_USER, TEST_PASS
+make test-live
+```
+
+By default mutating admin endpoints (initial seeds, match writes, activate/deactivate) are **skipped** so the suite is safe to point at staging. To include them, set `RUN_MUTATING=1` in `.env`.
+
+## Layout
+
+```
+api-tests/
+  hurl/          numbered test files; run in order so token + bet_uuid propagate
+  fixtures/      JSON request bodies referenced from hurl files
+  mock/          Node mock server (single file, no deps)
+  Makefile       `make test` / `make test-live` / `make mock` / `make clean`
+  .env.example   copy to .env for live runs
+```
+
+## Endpoint coverage
+
+| Group      | Method | Path                                       | File                             |
+|------------|--------|--------------------------------------------|----------------------------------|
+| Auth       | POST   | `/authentication/authentications`          | `01-auth.hurl`                   |
+| Bets       | POST   | `/bets/`                                   | `02-bets.hurl`                   |
+| Bets       | GET    | `/bets/{uuid}`                             | `02-bets.hurl`                   |
+| Bets       | PUT    | `/bets/{uuid}`                             | `02-bets.hurl`                   |
+| Activities | GET    | `/activities`                              | `03-activities.hurl`             |
+| Activities | POST   | `/activities/comments`                     | `03-activities.hurl`             |
+| Activities | POST   | `/activities/blogs` (auth)                 | `03-activities.hurl`             |
+| Matches    | GET    | `/bets/results/matches/`                   | `04-results-matches.hurl`        |
+| Matches    | PUT    | `/bets/results/matches/{id}` (auth)        | `04-results-matches.hurl`        |
+| Matches    | POST   | `/bets/results/matches/initial/` (auth)    | `04-results-matches.hurl`        |
+| Topscorer  | GET    | `/bets/results/topscorer/`                 | `05-results-topscorer.hurl`      |
+| Topscorer  | POST   | `/bets/results/topscorer/` (auth)          | `05-results-topscorer.hurl`      |
+| Topscorer  | POST   | `/bets/results/topscorer/initial/` (auth)  | `05-results-topscorer.hurl`      |
+| Knockouts  | GET    | `/bets/results/knockouts/`                 | `06-results-knockouts.hurl`      |
+| Knockouts  | POST   | `/bets/results/knockouts/` (auth)          | `06-results-knockouts.hurl`      |
+| Knockouts  | POST   | `/bets/results/knockouts/initial/` (auth)  | `06-results-knockouts.hurl`      |
+| Ranking    | GET    | `/bets/ranking/`                           | `07-results-ranking.hurl`        |
+| Ranking    | GET    | `/bets/ranking/{uuid}`                     | `07-results-ranking.hurl`        |
+| Ranking    | POST   | `/bets/ranking/initial/` (auth)            | `07-results-ranking.hurl`        |
+| Admin      | GET    | `/bets/`                                   | `07-results-ranking.hurl`        |
+| Admin      | POST   | `/bets/activate/{uuid}` (auth)             | `07-results-ranking.hurl`        |
+| Admin      | POST   | `/bets/deactivate/{uuid}` (auth)           | `07-results-ranking.hurl`        |
+
+Every protected endpoint also has a negative test that asserts an unauthenticated request is rejected.
+
+## Notes
+
+- Hurl runs the files in lexical order; `01-auth.hurl` captures `{{token}}` and later files reuse it, and `02-bets.hurl` captures `{{bet_uuid}}` for `07-results-ranking.hurl`.
+- The mock's state is per-process — it resets on every `make test` run.
+- Against a live backend, `bet_uuid` comes from whatever the server returned, so ranking detail lookup hits a real, just-created bet.
+- To add an endpoint: drop a new `NN-name.hurl` into `hurl/` and (if the backend is stateful) extend `mock/server.mjs`.

--- a/api-tests/fixtures/bet-update.json
+++ b/api-tests/fixtures/bet-update.json
@@ -1,0 +1,19 @@
+{
+  "bet": {
+    "answers": {
+      "matches": {},
+      "bracket": {},
+      "topscorer": {}
+    },
+    "uuid": null,
+    "active": true,
+    "participant": {
+      "name": "Mock Updated",
+      "address": "Teststraat 1",
+      "residence": "Amsterdam",
+      "phone": "0612345678",
+      "email": "mock@example.com",
+      "howyouknowus": "via een vriend"
+    }
+  }
+}

--- a/api-tests/fixtures/bet.json
+++ b/api-tests/fixtures/bet.json
@@ -1,0 +1,19 @@
+{
+  "bet": {
+    "answers": {
+      "matches": {},
+      "bracket": {},
+      "topscorer": {}
+    },
+    "uuid": null,
+    "active": true,
+    "participant": {
+      "name": "Mock Deelnemer",
+      "address": "Teststraat 1",
+      "residence": "Amsterdam",
+      "phone": "0612345678",
+      "email": "mock@example.com",
+      "howyouknowus": "via een vriend"
+    }
+  }
+}

--- a/api-tests/fixtures/blog.json
+++ b/api-tests/fixtures/blog.json
@@ -1,0 +1,8 @@
+{
+  "blog": {
+    "author": "Mock",
+    "title": "Test post",
+    "msg": ["Regel een", "", "Regel drie"],
+    "passphrase": "open-sesame"
+  }
+}

--- a/api-tests/fixtures/comment.json
+++ b/api-tests/fixtures/comment.json
@@ -1,0 +1,6 @@
+{
+  "comment": {
+    "author": "Mock",
+    "msg": ["Hallo", "wereld"]
+  }
+}

--- a/api-tests/fixtures/knockouts-results.json
+++ b/api-tests/fixtures/knockouts-results.json
@@ -1,0 +1,11 @@
+{
+  "teams": {
+    "ned": {
+      "team": { "teamID": "ned", "name": "Nederland" },
+      "roundsQualified": {
+        "1": "in",
+        "2": "tbd"
+      }
+    }
+  }
+}

--- a/api-tests/fixtures/match-result.json
+++ b/api-tests/fixtures/match-result.json
@@ -1,0 +1,9 @@
+{
+  "match": "m1",
+  "group": "A",
+  "homeTeam": { "teamID": "ned", "name": "Nederland" },
+  "awayTeam": { "teamID": "sen", "name": "Senegal" },
+  "homeScore": 2,
+  "awayScore": 0,
+  "isSet": true
+}

--- a/api-tests/fixtures/match-results-initial.json
+++ b/api-tests/fixtures/match-results-initial.json
@@ -1,0 +1,13 @@
+{
+  "results": [
+    {
+      "match": "m1",
+      "group": "A",
+      "homeTeam": { "teamID": "ned", "name": "Nederland" },
+      "awayTeam": { "teamID": "sen", "name": "Senegal" },
+      "homeScore": 0,
+      "awayScore": 0,
+      "isSet": false
+    }
+  ]
+}

--- a/api-tests/fixtures/topscorer-results.json
+++ b/api-tests/fixtures/topscorer-results.json
@@ -1,0 +1,11 @@
+{
+  "topscorers": [
+    {
+      "hasQualified": "tbd",
+      "topscorer": {
+        "team": { "teamID": "ned", "name": "Nederland" },
+        "player": "Memphis Depay"
+      }
+    }
+  ]
+}

--- a/api-tests/hurl/01-auth.hurl
+++ b/api-tests/hurl/01-auth.hurl
@@ -1,0 +1,27 @@
+# Login + capture token for downstream tests.
+#
+# Expects variables: base_url, test_user, test_pass
+
+POST {{base_url}}/authentication/authentications
+Content-Type: application/json
+{
+  "username": "{{test_user}}",
+  "password": "{{test_pass}}"
+}
+HTTP 200
+[Captures]
+token: jsonpath "$.token"
+[Asserts]
+jsonpath "$.token" exists
+jsonpath "$.token" isString
+
+
+# Missing credentials should not succeed.
+
+POST {{base_url}}/authentication/authentications
+Content-Type: application/json
+{}
+HTTP *
+[Asserts]
+status >= 400
+status < 500

--- a/api-tests/hurl/02-bets.hurl
+++ b/api-tests/hurl/02-bets.hurl
@@ -1,0 +1,46 @@
+# Bets CRUD: login, create, fetch, update, 404.
+
+POST {{base_url}}/authentication/authentications
+Content-Type: application/json
+{
+  "username": "{{test_user}}",
+  "password": "{{test_pass}}"
+}
+HTTP 200
+[Captures]
+token: jsonpath "$.token"
+
+
+POST {{base_url}}/bets/
+Content-Type: application/json
+file,fixtures/bet.json;
+HTTP 200
+[Captures]
+bet_uuid: jsonpath "$.bet.uuid"
+[Asserts]
+jsonpath "$.bet.uuid" exists
+jsonpath "$.bet.uuid" isString
+jsonpath "$.bet.participant.name" exists
+
+
+GET {{base_url}}/bets/{{bet_uuid}}
+HTTP 200
+[Asserts]
+jsonpath "$.bet.uuid" == "{{bet_uuid}}"
+jsonpath "$.bet.active" isBoolean
+
+
+PUT {{base_url}}/bets/{{bet_uuid}}
+Content-Type: application/json
+file,fixtures/bet-update.json;
+HTTP 200
+[Asserts]
+jsonpath "$.bet.uuid" == "{{bet_uuid}}"
+jsonpath "$.bet.participant.name" == "Mock Updated"
+
+
+GET {{base_url}}/bets/does-not-exist-{{bet_uuid}}
+HTTP *
+[Asserts]
+status >= 400
+status < 500

--- a/api-tests/hurl/03-activities.hurl
+++ b/api-tests/hurl/03-activities.hurl
@@ -1,0 +1,43 @@
+# Activities feed: unauth read + comment, authed blog post.
+
+POST {{base_url}}/authentication/authentications
+Content-Type: application/json
+{
+  "username": "{{test_user}}",
+  "password": "{{test_pass}}"
+}
+HTTP 200
+[Captures]
+token: jsonpath "$.token"
+
+
+GET {{base_url}}/activities
+HTTP 200
+[Asserts]
+jsonpath "$.activities" isCollection
+
+
+POST {{base_url}}/activities/comments
+Content-Type: application/json
+file,fixtures/comment.json;
+HTTP 200
+[Asserts]
+jsonpath "$.activities" isCollection
+
+
+POST {{base_url}}/activities/blogs
+Authorization: Bearer {{token}}
+Content-Type: application/json
+file,fixtures/blog.json;
+HTTP 200
+[Asserts]
+jsonpath "$.activities" isCollection
+
+
+POST {{base_url}}/activities/blogs
+Content-Type: application/json
+file,fixtures/blog.json;
+HTTP *
+[Asserts]
+status >= 400
+status < 500

--- a/api-tests/hurl/04-results-matches.hurl
+++ b/api-tests/hurl/04-results-matches.hurl
@@ -1,0 +1,49 @@
+# Admin: match results list, initial seed, per-match update.
+# Mutating requests are gated behind RUN_MUTATING=1.
+
+POST {{base_url}}/authentication/authentications
+Content-Type: application/json
+{
+  "username": "{{test_user}}",
+  "password": "{{test_pass}}"
+}
+HTTP 200
+[Captures]
+token: jsonpath "$.token"
+
+
+GET {{base_url}}/bets/results/matches/
+HTTP 200
+[Asserts]
+jsonpath "$.results" isCollection
+
+
+POST {{base_url}}/bets/results/matches/initial/
+Authorization: Bearer {{token}}
+Content-Type: application/json
+[Options]
+skip: {{skip_mutating}}
+file,fixtures/match-results-initial.json;
+HTTP 200
+[Asserts]
+jsonpath "$.results" isCollection
+
+
+PUT {{base_url}}/bets/results/matches/m1
+Authorization: Bearer {{token}}
+Content-Type: application/json
+[Options]
+skip: {{skip_mutating}}
+file,fixtures/match-result.json;
+HTTP 200
+[Asserts]
+jsonpath "$.results" isCollection
+
+
+PUT {{base_url}}/bets/results/matches/m1
+Content-Type: application/json
+file,fixtures/match-result.json;
+HTTP *
+[Asserts]
+status >= 400
+status < 500

--- a/api-tests/hurl/05-results-topscorer.hurl
+++ b/api-tests/hurl/05-results-topscorer.hurl
@@ -1,0 +1,46 @@
+POST {{base_url}}/authentication/authentications
+Content-Type: application/json
+{
+  "username": "{{test_user}}",
+  "password": "{{test_pass}}"
+}
+HTTP 200
+[Captures]
+token: jsonpath "$.token"
+
+
+GET {{base_url}}/bets/results/topscorer/
+HTTP 200
+[Asserts]
+jsonpath "$.topscorers" isCollection
+
+
+POST {{base_url}}/bets/results/topscorer/initial/
+Authorization: Bearer {{token}}
+Content-Type: application/json
+[Options]
+skip: {{skip_mutating}}
+{}
+HTTP 200
+[Asserts]
+jsonpath "$.topscorers" isCollection
+
+
+POST {{base_url}}/bets/results/topscorer/
+Authorization: Bearer {{token}}
+Content-Type: application/json
+[Options]
+skip: {{skip_mutating}}
+file,fixtures/topscorer-results.json;
+HTTP 200
+[Asserts]
+jsonpath "$.topscorers" isCollection
+
+
+POST {{base_url}}/bets/results/topscorer/
+Content-Type: application/json
+file,fixtures/topscorer-results.json;
+HTTP *
+[Asserts]
+status >= 400
+status < 500

--- a/api-tests/hurl/06-results-knockouts.hurl
+++ b/api-tests/hurl/06-results-knockouts.hurl
@@ -1,0 +1,46 @@
+POST {{base_url}}/authentication/authentications
+Content-Type: application/json
+{
+  "username": "{{test_user}}",
+  "password": "{{test_pass}}"
+}
+HTTP 200
+[Captures]
+token: jsonpath "$.token"
+
+
+GET {{base_url}}/bets/results/knockouts/
+HTTP 200
+[Asserts]
+jsonpath "$.teams" exists
+
+
+POST {{base_url}}/bets/results/knockouts/initial/
+Authorization: Bearer {{token}}
+Content-Type: application/json
+[Options]
+skip: {{skip_mutating}}
+{}
+HTTP 200
+[Asserts]
+jsonpath "$.teams" exists
+
+
+POST {{base_url}}/bets/results/knockouts/
+Authorization: Bearer {{token}}
+Content-Type: application/json
+[Options]
+skip: {{skip_mutating}}
+file,fixtures/knockouts-results.json;
+HTTP 200
+[Asserts]
+jsonpath "$.teams" exists
+
+
+POST {{base_url}}/bets/results/knockouts/
+Content-Type: application/json
+file,fixtures/knockouts-results.json;
+HTTP *
+[Asserts]
+status >= 400
+status < 500

--- a/api-tests/hurl/07-results-ranking.hurl
+++ b/api-tests/hurl/07-results-ranking.hurl
@@ -1,0 +1,77 @@
+# Creates its own bet so ranking detail lookup hits a real uuid.
+
+POST {{base_url}}/authentication/authentications
+Content-Type: application/json
+{
+  "username": "{{test_user}}",
+  "password": "{{test_pass}}"
+}
+HTTP 200
+[Captures]
+token: jsonpath "$.token"
+
+
+POST {{base_url}}/bets/
+Content-Type: application/json
+file,fixtures/bet.json;
+HTTP 200
+[Captures]
+bet_uuid: jsonpath "$.bet.uuid"
+
+
+GET {{base_url}}/bets/ranking/
+HTTP 200
+[Asserts]
+jsonpath "$.summary" isCollection
+jsonpath "$.time" exists
+
+
+GET {{base_url}}/bets/ranking/{{bet_uuid}}
+HTTP 200
+[Asserts]
+jsonpath "$.uuid" == "{{bet_uuid}}"
+jsonpath "$.bet" exists
+
+
+POST {{base_url}}/bets/ranking/initial/
+Authorization: Bearer {{token}}
+Content-Type: application/json
+[Options]
+skip: {{skip_mutating}}
+HTTP 200
+[Asserts]
+jsonpath "$.summary" isCollection
+
+
+POST {{base_url}}/bets/ranking/initial/
+Content-Type: application/json
+HTTP *
+[Asserts]
+status >= 400
+status < 500
+
+
+GET {{base_url}}/bets/
+HTTP 200
+[Asserts]
+jsonpath "$" isCollection
+
+
+POST {{base_url}}/bets/deactivate/{{bet_uuid}}
+Authorization: Bearer {{token}}
+Content-Type: application/json
+[Options]
+skip: {{skip_mutating}}
+HTTP 200
+[Asserts]
+jsonpath "$.bet.active" == false
+
+
+POST {{base_url}}/bets/activate/{{bet_uuid}}
+Authorization: Bearer {{token}}
+Content-Type: application/json
+[Options]
+skip: {{skip_mutating}}
+HTTP 200
+[Asserts]
+jsonpath "$.bet.active" == true

--- a/api-tests/mock/server.mjs
+++ b/api-tests/mock/server.mjs
@@ -1,0 +1,275 @@
+// Stateful HTTP mock of the Tournaments backend.
+// Covers every endpoint the Elm client calls. Accepts any non-empty username/password,
+// issues a fixed Bearer token, and validates it for protected routes.
+
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+
+const PORT = Number(process.env.MOCK_PORT ?? 8787);
+const TOKEN = "mock-token-abc123";
+
+const state = {
+  bets: new Map(), // uuid -> bet
+  activities: [],
+  matchResults: { results: [] },
+  topscorerResults: { topscorers: [] },
+  knockoutsResults: { teams: {} },
+  ranking: { summary: [], time: Math.floor(Date.now() / 1000) },
+  rankingDetails: new Map(), // uuid -> details
+};
+
+function send(res, status, body, extraHeaders = {}) {
+  const json = body === undefined ? "" : JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(json),
+    ...extraHeaders,
+  });
+  res.end(json);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) return resolve(null);
+      try {
+        resolve(JSON.parse(raw));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function requireAuth(req, res) {
+  const auth = req.headers["authorization"];
+  if (auth !== `Bearer ${TOKEN}`) {
+    send(res, 401, { error: "unauthorized" });
+    return false;
+  }
+  return true;
+}
+
+function makeBetSummary(bet) {
+  return {
+    name:
+      bet.participant?.name ??
+      bet.bet?.participant?.name ??
+      "onbekend",
+    active: bet.active ?? bet.bet?.active ?? true,
+    uuid: bet.uuid ?? bet.bet?.uuid ?? null,
+  };
+}
+
+function wrapBet(bet) {
+  return { bet };
+}
+
+function unwrapBet(body) {
+  return body?.bet ?? body;
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const { method } = req;
+  const path = url.pathname;
+
+  let body = null;
+  if (method === "POST" || method === "PUT") {
+    try {
+      body = await readBody(req);
+    } catch {
+      return send(res, 400, { error: "invalid json" });
+    }
+  }
+
+  // Authentication
+  if (method === "POST" && path === "/authentication/authentications") {
+    if (!body?.username || !body?.password) {
+      return send(res, 400, { error: "missing credentials" });
+    }
+    return send(res, 200, { token: TOKEN });
+  }
+
+  // Activities
+  if (method === "GET" && path === "/activities") {
+    return send(res, 200, { activities: state.activities });
+  }
+  if (method === "POST" && path === "/activities/comments") {
+    const c = body?.comment ?? {};
+    const activity = {
+      type: "comment",
+      meta: {
+        date: Date.now(),
+        active: true,
+        uuid: randomUUID(),
+      },
+      author: c.author ?? "",
+      msg: c.msg ?? [""],
+    };
+    state.activities.unshift(activity);
+    return send(res, 200, { activities: state.activities });
+  }
+  if (method === "POST" && path === "/activities/blogs") {
+    if (!requireAuth(req, res)) return;
+    const b = body?.blog ?? {};
+    const activity = {
+      type: "blog",
+      meta: {
+        date: Date.now(),
+        active: true,
+        uuid: randomUUID(),
+      },
+      author: b.author ?? "",
+      title: b.title ?? "",
+      msg: b.msg ?? [""],
+    };
+    state.activities.unshift(activity);
+    return send(res, 200, { activities: state.activities });
+  }
+
+  // Bets (user flow)
+  if (method === "POST" && path === "/bets/") {
+    const inner = unwrapBet(body) ?? {};
+    const uuid = randomUUID();
+    const saved = { ...inner, uuid, active: inner.active ?? true };
+    state.bets.set(uuid, saved);
+    return send(res, 200, wrapBet(saved));
+  }
+  const betIdMatch = path.match(/^\/bets\/([^/]+)$/);
+  if (betIdMatch) {
+    const uuid = betIdMatch[1];
+    if (method === "GET") {
+      const found = state.bets.get(uuid);
+      if (!found) return send(res, 404, { error: "not found" });
+      return send(res, 200, wrapBet(found));
+    }
+    if (method === "PUT") {
+      const inner = unwrapBet(body) ?? {};
+      const saved = { ...inner, uuid };
+      state.bets.set(uuid, saved);
+      return send(res, 200, wrapBet(saved));
+    }
+  }
+
+  // Bets list + admin toggles
+  if (method === "GET" && path === "/bets/") {
+    const list = [...state.bets.values()].map(makeBetSummary);
+    return send(res, 200, list);
+  }
+  const activateMatch = path.match(/^\/bets\/(activate|deactivate)\/([^/]+)$/);
+  if (method === "POST" && activateMatch) {
+    if (!requireAuth(req, res)) return;
+    const [, action, uuid] = activateMatch;
+    const bet = state.bets.get(uuid);
+    if (!bet) return send(res, 404, { error: "not found" });
+    bet.active = action === "activate";
+    state.bets.set(uuid, bet);
+    return send(res, 200, wrapBet(bet));
+  }
+
+  // Results: matches
+  if (method === "GET" && path === "/bets/results/matches/") {
+    return send(res, 200, state.matchResults);
+  }
+  if (method === "POST" && path === "/bets/results/matches/initial/") {
+    if (!requireAuth(req, res)) return;
+    state.matchResults = body ?? { results: [] };
+    return send(res, 200, state.matchResults);
+  }
+  const matchResultMatch = path.match(/^\/bets\/results\/matches\/([^/]+)$/);
+  if (method === "PUT" && matchResultMatch) {
+    if (!requireAuth(req, res)) return;
+    const matchId = matchResultMatch[1];
+    const incoming = body ?? {};
+    const existing = state.matchResults.results.find((r) => r.match === matchId);
+    if (existing) Object.assign(existing, incoming);
+    else state.matchResults.results.push(incoming);
+    return send(res, 200, state.matchResults);
+  }
+
+  // Results: topscorer
+  if (method === "GET" && path === "/bets/results/topscorer/") {
+    return send(res, 200, state.topscorerResults);
+  }
+  if (method === "POST" && path === "/bets/results/topscorer/initial/") {
+    if (!requireAuth(req, res)) return;
+    state.topscorerResults = { topscorers: [] };
+    return send(res, 200, state.topscorerResults);
+  }
+  if (method === "POST" && path === "/bets/results/topscorer/") {
+    if (!requireAuth(req, res)) return;
+    state.topscorerResults = body ?? { topscorers: [] };
+    return send(res, 200, state.topscorerResults);
+  }
+
+  // Results: knockouts
+  if (method === "GET" && path === "/bets/results/knockouts/") {
+    return send(res, 200, state.knockoutsResults);
+  }
+  if (method === "POST" && path === "/bets/results/knockouts/initial/") {
+    if (!requireAuth(req, res)) return;
+    state.knockoutsResults = { teams: {} };
+    return send(res, 200, state.knockoutsResults);
+  }
+  if (method === "POST" && path === "/bets/results/knockouts/") {
+    if (!requireAuth(req, res)) return;
+    state.knockoutsResults = body ?? { teams: {} };
+    return send(res, 200, state.knockoutsResults);
+  }
+
+  // Ranking
+  if (method === "GET" && path === "/bets/ranking/") {
+    return send(res, 200, state.ranking);
+  }
+  const rankingDetailMatch = path.match(/^\/bets\/ranking\/([^/]+)$/);
+  if (method === "GET" && rankingDetailMatch) {
+    const uuid = rankingDetailMatch[1];
+    const details = state.rankingDetails.get(uuid) ?? {
+      name: "Mock Deelnemer",
+      rounds: [],
+      topscorer: 0,
+      total: 0,
+      uuid,
+      bet: {
+        answers: { matches: {}, bracket: {}, topscorer: {} },
+        uuid,
+        active: true,
+        participant: {
+          name: "Mock",
+          address: "",
+          residence: "",
+          phone: "",
+          email: "",
+          howyouknowus: "",
+        },
+      },
+    };
+    return send(res, 200, details);
+  }
+  if (method === "POST" && path === "/bets/ranking/initial/") {
+    if (!requireAuth(req, res)) return;
+    state.ranking = {
+      summary: [],
+      time: Math.floor(Date.now() / 1000),
+    };
+    return send(res, 200, state.ranking);
+  }
+
+  send(res, 404, { error: `no mock route for ${method} ${path}` });
+});
+
+server.listen(PORT, () => {
+  console.log(`[mock] listening on http://localhost:${PORT}`);
+});
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => {
+    console.log(`[mock] ${sig} received, shutting down`);
+    server.close(() => process.exit(0));
+  });
+}


### PR DESCRIPTION
Hurl-based tests covering every endpoint the Elm client calls (auth, bets CRUD, activities, matches/topscorer/knockouts/ranking results + admin).

Ships a stateful Node mock server (zero deps) so `make test` works offline on a fresh clone. `make test-live` runs the same files against a real backend configured via .env; mutating admin writes are gated behind RUN_MUTATING=1 so the suite is safe against staging by default.