### PR TITLE
feat: add SimpleBracket type and parallel SimpleBet with API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,17 @@ BUILD = build
 HTML = src/index.html
 ASSETS = assets
 ASSETSDIR = $(BUILD)/assets
+OPENAPI_SPEC = docs/openapi.json
 
 # From https://dimiterpetrov.com/blog/elm-single-page-application-setup/
 
 build: build-directory html js assets pwa
 
 debug: build-directory html js-debug assets
+
+lint-openapi:
+	echo "Validating OpenAPI spec..."
+	npx --yes @apidevtools/swagger-cli@latest validate $(OPENAPI_SPEC)
 
 build-directory:
 	echo "Creating build directory..."
@@ -41,4 +46,4 @@ clean:
 	rm -rf ./build
 
 
-.PHONY: build debug build-directory html assets pwa js js-debug clean
+.PHONY: build debug build-directory html assets pwa js js-debug clean lint-openapi

--- a/api-tests/fixtures/bet-flat-update.json
+++ b/api-tests/fixtures/bet-flat-update.json
@@ -1,0 +1,59 @@
+{
+  "bet": {
+    "answers": {
+      "matches": {},
+      "bracket": {
+        "bracket": {
+          "nodes": [
+            {
+              "kind": "team",
+              "slot": "A1",
+              "candidate": { "candidate-type": "first-place", "groups": ["A"] },
+              "qualifier": { "teamID": "NED", "teamName": "Netherlands" },
+              "hasQualified": "TBD"
+            },
+            {
+              "kind": "team",
+              "slot": "B2",
+              "candidate": { "candidate-type": "second-place", "groups": ["B"] },
+              "qualifier": { "teamID": "ENG", "teamName": "England" },
+              "hasQualified": "TBD"
+            },
+            {
+              "kind": "team",
+              "slot": "T1",
+              "candidate": {
+                "candidate-type": "best-thirds-from",
+                "groups": ["C", "E", "F", "H", "I"]
+              },
+              "qualifier": null,
+              "hasQualified": "TBD"
+            },
+            {
+              "kind": "match",
+              "slot": "m73",
+              "round": 1,
+              "home": "A1",
+              "away": "B2",
+              "winner": "AwayTeam",
+              "winningTeam": { "teamID": "ENG", "teamName": "England" },
+              "hasQualified": "TBD"
+            }
+          ]
+        },
+        "points": null
+      },
+      "topscorer": {}
+    },
+    "uuid": null,
+    "active": true,
+    "participant": {
+      "name": "Mock Updated Flat",
+      "address": "Teststraat 1",
+      "residence": "Amsterdam",
+      "phone": "0612345678",
+      "email": "mock@example.com",
+      "howyouknowus": "via een vriend"
+    }
+  }
+}

--- a/api-tests/fixtures/bet-flat.json
+++ b/api-tests/fixtures/bet-flat.json
@@ -1,0 +1,59 @@
+{
+  "bet": {
+    "answers": {
+      "matches": {},
+      "bracket": {
+        "bracket": {
+          "nodes": [
+            {
+              "kind": "team",
+              "slot": "A1",
+              "candidate": { "candidate-type": "first-place", "groups": ["A"] },
+              "qualifier": { "teamID": "NED", "teamName": "Netherlands" },
+              "hasQualified": "TBD"
+            },
+            {
+              "kind": "team",
+              "slot": "B2",
+              "candidate": { "candidate-type": "second-place", "groups": ["B"] },
+              "qualifier": { "teamID": "ENG", "teamName": "England" },
+              "hasQualified": "TBD"
+            },
+            {
+              "kind": "team",
+              "slot": "T1",
+              "candidate": {
+                "candidate-type": "best-thirds-from",
+                "groups": ["C", "E", "F", "H", "I"]
+              },
+              "qualifier": null,
+              "hasQualified": "TBD"
+            },
+            {
+              "kind": "match",
+              "slot": "m73",
+              "round": 1,
+              "home": "A1",
+              "away": "B2",
+              "winner": "HomeTeam",
+              "winningTeam": { "teamID": "NED", "teamName": "Netherlands" },
+              "hasQualified": "TBD"
+            }
+          ]
+        },
+        "points": null
+      },
+      "topscorer": {}
+    },
+    "uuid": null,
+    "active": true,
+    "participant": {
+      "name": "Mock Deelnemer",
+      "address": "Teststraat 1",
+      "residence": "Amsterdam",
+      "phone": "0612345678",
+      "email": "mock@example.com",
+      "howyouknowus": "via een vriend"
+    }
+  }
+}

--- a/api-tests/fixtures/knockouts-results.json
+++ b/api-tests/fixtures/knockouts-results.json
@@ -1,7 +1,7 @@
 {
   "teams": {
     "ned": {
-      "team": { "teamID": "ned", "name": "Nederland" },
+      "team": { "teamID": "ned", "teamName": "Nederland" },
       "roundsQualified": {
         "1": "in",
         "2": "tbd"

--- a/api-tests/fixtures/match-result.json
+++ b/api-tests/fixtures/match-result.json
@@ -1,8 +1,8 @@
 {
   "match": "m1",
   "group": "A",
-  "homeTeam": { "teamID": "ned", "name": "Nederland" },
-  "awayTeam": { "teamID": "sen", "name": "Senegal" },
+  "homeTeam": { "teamID": "ned", "teamName": "Nederland" },
+  "awayTeam": { "teamID": "sen", "teamName": "Senegal" },
   "homeScore": 2,
   "awayScore": 0,
   "isSet": true

--- a/api-tests/fixtures/match-results-initial.json
+++ b/api-tests/fixtures/match-results-initial.json
@@ -3,8 +3,8 @@
     {
       "match": "m1",
       "group": "A",
-      "homeTeam": { "teamID": "ned", "name": "Nederland" },
-      "awayTeam": { "teamID": "sen", "name": "Senegal" },
+      "homeTeam": { "teamID": "ned", "teamName": "Nederland" },
+      "awayTeam": { "teamID": "sen", "teamName": "Senegal" },
       "homeScore": 0,
       "awayScore": 0,
       "isSet": false

--- a/api-tests/fixtures/topscorer-results.json
+++ b/api-tests/fixtures/topscorer-results.json
@@ -3,7 +3,7 @@
     {
       "hasQualified": "tbd",
       "topscorer": {
-        "team": { "teamID": "ned", "name": "Nederland" },
+        "team": { "teamID": "ned", "teamName": "Nederland" },
         "player": "Memphis Depay"
       }
     }

--- a/api-tests/hurl/02b-bets-flat.hurl
+++ b/api-tests/hurl/02b-bets-flat.hurl
@@ -1,0 +1,48 @@
+# Bets (flat bracket wire format): login, create, fetch, update, 404.
+
+POST {{base_url}}/authentication/authentications
+Content-Type: application/json
+{
+  "username": "{{test_user}}",
+  "password": "{{test_pass}}"
+}
+HTTP 200
+[Captures]
+token: jsonpath "$.token"
+
+
+POST {{base_url}}/bets/flat/
+Content-Type: application/json
+file,fixtures/bet-flat.json;
+HTTP 200
+[Captures]
+bet_flat_uuid: jsonpath "$.bet.uuid"
+[Asserts]
+jsonpath "$.bet.uuid" exists
+jsonpath "$.bet.uuid" isString
+jsonpath "$.bet.answers.bracket.bracket.nodes" isCollection
+jsonpath "$.bet.answers.bracket.bracket.nodes[0].slot" exists
+jsonpath "$.bet.answers.bracket.bracket.nodes[0].kind" exists
+
+
+GET {{base_url}}/bets/flat/{{bet_flat_uuid}}
+HTTP 200
+[Asserts]
+jsonpath "$.bet.uuid" == "{{bet_flat_uuid}}"
+jsonpath "$.bet.answers.bracket.bracket.nodes" isCollection
+
+
+PUT {{base_url}}/bets/flat/{{bet_flat_uuid}}
+Content-Type: application/json
+file,fixtures/bet-flat-update.json;
+HTTP 200
+[Asserts]
+jsonpath "$.bet.uuid" == "{{bet_flat_uuid}}"
+jsonpath "$.bet.participant.name" == "Mock Updated Flat"
+
+
+GET {{base_url}}/bets/flat/does-not-exist-{{bet_flat_uuid}}
+HTTP *
+[Asserts]
+status >= 400
+status < 500

--- a/api-tests/mock/server.mjs
+++ b/api-tests/mock/server.mjs
@@ -10,6 +10,7 @@ const TOKEN = "mock-token-abc123";
 
 const state = {
   bets: new Map(), // uuid -> bet
+  betsFlat: new Map(), // uuid -> bet with flat bracket
   activities: [],
   matchResults: { results: [] },
   topscorerResults: { topscorers: [] },
@@ -156,6 +157,31 @@ const server = createServer(async (req, res) => {
     }
   }
 
+  // Bets (flat wire format) — separate storage so the echoed bracket
+  // stays in the same flat shape the Elm client sent.
+  if (method === "POST" && path === "/bets/flat/") {
+    const inner = unwrapBet(body) ?? {};
+    const uuid = randomUUID();
+    const saved = { ...inner, uuid, active: inner.active ?? true };
+    state.betsFlat.set(uuid, saved);
+    return send(res, 200, wrapBet(saved));
+  }
+  const betFlatIdMatch = path.match(/^\/bets\/flat\/([^/]+)$/);
+  if (betFlatIdMatch) {
+    const uuid = betFlatIdMatch[1];
+    if (method === "GET") {
+      const found = state.betsFlat.get(uuid);
+      if (!found) return send(res, 404, { error: "not found" });
+      return send(res, 200, wrapBet(found));
+    }
+    if (method === "PUT") {
+      const inner = unwrapBet(body) ?? {};
+      const saved = { ...inner, uuid };
+      state.betsFlat.set(uuid, saved);
+      return send(res, 200, wrapBet(saved));
+    }
+  }
+
   // Bets list + admin toggles
   if (method === "GET" && path === "/bets/") {
     const list = [...state.bets.values()].map(makeBetSummary);
@@ -165,10 +191,17 @@ const server = createServer(async (req, res) => {
   if (method === "POST" && activateMatch) {
     if (!requireAuth(req, res)) return;
     const [, action, uuid] = activateMatch;
-    const bet = state.bets.get(uuid);
-    if (!bet) return send(res, 404, { error: "not found" });
+    // Toggle whichever store holds this uuid. Flat-created bets land in
+    // betsFlat; legacy nested-created bets land in bets.
+    const store = state.betsFlat.has(uuid)
+      ? state.betsFlat
+      : state.bets.has(uuid)
+        ? state.bets
+        : null;
+    if (!store) return send(res, 404, { error: "not found" });
+    const bet = store.get(uuid);
     bet.active = action === "activate";
-    state.bets.set(uuid, bet);
+    store.set(uuid, bet);
     return send(res, 200, wrapBet(bet));
   }
 
@@ -236,7 +269,11 @@ const server = createServer(async (req, res) => {
       total: 0,
       uuid,
       bet: {
-        answers: { matches: {}, bracket: {}, topscorer: {} },
+        answers: {
+          matches: {},
+          bracket: { bracket: { nodes: [] }, points: null },
+          topscorer: { topscorer: { name: null, team: null }, points: null },
+        },
         uuid,
         active: true,
         participant: {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,1190 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Tournaments API (flat bet variant)",
+    "version": "1.0.0",
+    "description": "HTTP contract for the Tournaments backend as consumed by the Elm client. Bet CRUD uses the flat bracket wire format at /bets/flat/. Source of truth for schemas is the Elm encoders/decoders under src/; the api-tests mock in api-tests/mock/server.mjs serves as the reference implementation."
+  },
+  "servers": [
+    { "url": "http://localhost:8787", "description": "Local mock (api-tests/mock/server.mjs)" }
+  ],
+  "tags": [
+    { "name": "Authentication" },
+    { "name": "Bets" },
+    { "name": "Admin" },
+    { "name": "Activities" },
+    { "name": "Match results" },
+    { "name": "Topscorer results" },
+    { "name": "Knockouts results" },
+    { "name": "Ranking" }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Token issued by POST /authentication/authentications. Sent as Authorization: Bearer <token>."
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": { "type": "string" }
+        }
+      },
+      "Group": {
+        "type": "string",
+        "enum": ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"]
+      },
+      "Round": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 6,
+        "description": "Tournament round number. 1 = last-32, 2 = last-16, 3 = quarter-final, 4 = semi-final, 5 = final, 6 = unused."
+      },
+      "HasQualified": {
+        "type": "string",
+        "enum": ["TBD", "In", "Out"]
+      },
+      "Winner": {
+        "type": ["string", "null"],
+        "enum": ["HomeTeam", "AwayTeam", null]
+      },
+      "Team": {
+        "type": "object",
+        "required": ["teamID", "teamName"],
+        "properties": {
+          "teamID": { "type": "string", "examples": ["NED"] },
+          "teamName": { "type": "string", "examples": ["Netherlands"] }
+        }
+      },
+      "Score": {
+        "type": "array",
+        "description": "[homeScore, awayScore]. Either element may be null while the bettor has only filled one side.",
+        "minItems": 2,
+        "maxItems": 2,
+        "prefixItems": [
+          { "type": ["integer", "null"] },
+          { "type": ["integer", "null"] }
+        ]
+      },
+      "Stadium": {
+        "type": "object",
+        "required": ["stadium", "town"],
+        "properties": {
+          "stadium": { "type": "string" },
+          "town": { "type": "string" }
+        }
+      },
+      "Match": {
+        "type": "object",
+        "required": ["matchID", "group", "home", "away", "time", "stadium"],
+        "properties": {
+          "matchID": { "type": "string", "examples": ["m1"] },
+          "group": { "$ref": "#/components/schemas/Group" },
+          "home": { "$ref": "#/components/schemas/Team" },
+          "away": { "$ref": "#/components/schemas/Team" },
+          "time": {
+            "type": "integer",
+            "description": "Kickoff time as Unix epoch milliseconds."
+          },
+          "stadium": { "$ref": "#/components/schemas/Stadium" }
+        }
+      },
+      "AnswerGroupMatch": {
+        "type": "object",
+        "required": ["group", "match", "score", "points"],
+        "properties": {
+          "group": { "$ref": "#/components/schemas/Group" },
+          "match": { "$ref": "#/components/schemas/Match" },
+          "score": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/Score" },
+              { "type": "null" }
+            ]
+          },
+          "points": { "type": ["integer", "null"] }
+        }
+      },
+      "AnswerGroupMatches": {
+        "type": "object",
+        "description": "Map keyed by match ID (e.g. \"m1\") whose values are AnswerGroupMatch objects.",
+        "additionalProperties": { "$ref": "#/components/schemas/AnswerGroupMatch" }
+      },
+      "Candidate": {
+        "type": "object",
+        "description": "Definition of which group position(s) can fill a team slot in the bracket.",
+        "required": ["candidate-type", "groups"],
+        "properties": {
+          "candidate-type": {
+            "type": "string",
+            "enum": ["first-place", "second-place", "best-thirds-from"]
+          },
+          "groups": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Group" },
+            "minItems": 1,
+            "description": "For first-place/second-place the array holds exactly one group. For best-thirds-from it holds the candidate groups whose third-placed team could land in this slot."
+          }
+        }
+      },
+      "FlatBracketNode": {
+        "oneOf": [
+          { "$ref": "#/components/schemas/FlatBracketTeamNode" },
+          { "$ref": "#/components/schemas/FlatBracketMatchNode" }
+        ],
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "team": "#/components/schemas/FlatBracketTeamNode",
+            "match": "#/components/schemas/FlatBracketMatchNode"
+          }
+        }
+      },
+      "FlatBracketTeamNode": {
+        "type": "object",
+        "required": ["kind", "slot", "candidate", "qualifier", "hasQualified"],
+        "properties": {
+          "kind": { "type": "string", "const": "team" },
+          "slot": {
+            "type": "string",
+            "description": "Unique slot identifier. Group-position slots follow the pattern <Group><1|2> (e.g. A1, B2); best-thirds slots use T1..T8.",
+            "examples": ["A1", "T1"]
+          },
+          "candidate": { "$ref": "#/components/schemas/Candidate" },
+          "qualifier": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/Team" },
+              { "type": "null" }
+            ],
+            "description": "The team the bettor placed into this slot (or null if still empty)."
+          },
+          "hasQualified": { "$ref": "#/components/schemas/HasQualified" }
+        }
+      },
+      "FlatBracketMatchNode": {
+        "type": "object",
+        "required": [
+          "kind",
+          "slot",
+          "round",
+          "home",
+          "away",
+          "winner",
+          "winningTeam",
+          "hasQualified"
+        ],
+        "properties": {
+          "kind": { "type": "string", "const": "match" },
+          "slot": {
+            "type": "string",
+            "description": "Match slot identifier (e.g. m73, m104).",
+            "examples": ["m73", "m104"]
+          },
+          "round": { "$ref": "#/components/schemas/Round" },
+          "home": {
+            "type": "string",
+            "description": "Slot of the home side (references another FlatBracketNode by slot)."
+          },
+          "away": {
+            "type": "string",
+            "description": "Slot of the away side (references another FlatBracketNode by slot)."
+          },
+          "winner": { "$ref": "#/components/schemas/Winner" },
+          "winningTeam": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/Team" },
+              { "type": "null" }
+            ],
+            "description": "Calculated outcome — the team resolved by following the winner pointers down to a leaf qualifier. Write-only: the decoder ignores this and recomputes it on expand."
+          },
+          "hasQualified": { "$ref": "#/components/schemas/HasQualified" }
+        }
+      },
+      "FlatBracket": {
+        "type": "object",
+        "required": ["nodes"],
+        "properties": {
+          "nodes": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/FlatBracketNode" },
+            "description": "Unordered list of every bracket node. Match nodes reference children by slot; the tree is rebuilt by finding the single node that no match references as home/away."
+          }
+        }
+      },
+      "AnswerFlatBracket": {
+        "type": "object",
+        "required": ["bracket", "points"],
+        "properties": {
+          "bracket": { "$ref": "#/components/schemas/FlatBracket" },
+          "points": { "type": ["integer", "null"] }
+        }
+      },
+      "Topscorer": {
+        "type": "object",
+        "required": ["name", "team"],
+        "properties": {
+          "name": { "type": ["string", "null"] },
+          "team": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/Team" },
+              { "type": "null" }
+            ]
+          }
+        }
+      },
+      "AnswerTopscorer": {
+        "type": "object",
+        "required": ["topscorer", "points"],
+        "properties": {
+          "topscorer": { "$ref": "#/components/schemas/Topscorer" },
+          "points": { "type": ["integer", "null"] }
+        }
+      },
+      "AnswersFlat": {
+        "type": "object",
+        "required": ["matches", "bracket", "topscorer"],
+        "properties": {
+          "matches": { "$ref": "#/components/schemas/AnswerGroupMatches" },
+          "bracket": { "$ref": "#/components/schemas/AnswerFlatBracket" },
+          "topscorer": { "$ref": "#/components/schemas/AnswerTopscorer" }
+        }
+      },
+      "Participant": {
+        "type": "object",
+        "required": ["name", "address", "residence", "phone", "email", "howyouknowus"],
+        "properties": {
+          "name": { "type": ["string", "null"] },
+          "address": { "type": ["string", "null"] },
+          "residence": { "type": ["string", "null"] },
+          "phone": { "type": ["string", "null"] },
+          "email": { "type": ["string", "null"] },
+          "howyouknowus": { "type": ["string", "null"] }
+        }
+      },
+      "BetFlat": {
+        "type": "object",
+        "required": ["bet"],
+        "properties": {
+          "bet": {
+            "type": "object",
+            "required": ["answers", "uuid", "active", "participant"],
+            "properties": {
+              "answers": { "$ref": "#/components/schemas/AnswersFlat" },
+              "uuid": {
+                "type": ["string", "null"],
+                "description": "Null on create; set by the server on first POST and preserved on subsequent PUTs."
+              },
+              "active": { "type": "boolean" },
+              "participant": { "$ref": "#/components/schemas/Participant" }
+            }
+          }
+        }
+      },
+      "BetSummaryLine": {
+        "type": "object",
+        "required": ["name", "active", "uuid"],
+        "properties": {
+          "name": { "type": "string" },
+          "active": { "type": "boolean" },
+          "uuid": { "type": "string" }
+        }
+      },
+      "ActivityMeta": {
+        "type": "object",
+        "required": ["date", "active", "uuid"],
+        "properties": {
+          "date": { "type": "integer", "description": "Unix epoch milliseconds." },
+          "active": { "type": "boolean" },
+          "uuid": { "type": "string" }
+        }
+      },
+      "Activity": {
+        "oneOf": [
+          { "$ref": "#/components/schemas/ActivityComment" },
+          { "$ref": "#/components/schemas/ActivityBlog" },
+          { "$ref": "#/components/schemas/ActivityNewBet" },
+          { "$ref": "#/components/schemas/ActivityNewRanking" }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "comment": "#/components/schemas/ActivityComment",
+            "blog": "#/components/schemas/ActivityBlog",
+            "new-bet": "#/components/schemas/ActivityNewBet",
+            "new-ranking": "#/components/schemas/ActivityNewRanking"
+          }
+        }
+      },
+      "ActivityComment": {
+        "type": "object",
+        "required": ["type", "meta", "author", "msg"],
+        "properties": {
+          "type": { "type": "string", "const": "comment" },
+          "meta": { "$ref": "#/components/schemas/ActivityMeta" },
+          "author": { "type": "string" },
+          "msg": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Each element is one line of the message body (joined with \\n on the client)."
+          }
+        }
+      },
+      "ActivityBlog": {
+        "type": "object",
+        "required": ["type", "meta", "author", "title", "msg"],
+        "properties": {
+          "type": { "type": "string", "const": "blog" },
+          "meta": { "$ref": "#/components/schemas/ActivityMeta" },
+          "author": { "type": "string" },
+          "title": { "type": "string" },
+          "msg": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "ActivityNewBet": {
+        "type": "object",
+        "required": ["type", "meta", "name", "bet-uuid"],
+        "properties": {
+          "type": { "type": "string", "const": "new-bet" },
+          "meta": { "$ref": "#/components/schemas/ActivityMeta" },
+          "name": { "type": "string" },
+          "bet-uuid": { "type": "string" }
+        }
+      },
+      "ActivityNewRanking": {
+        "type": "object",
+        "required": ["type", "meta"],
+        "properties": {
+          "type": { "type": "string", "const": "new-ranking" },
+          "meta": { "$ref": "#/components/schemas/ActivityMeta" }
+        }
+      },
+      "ActivitiesResponse": {
+        "type": "object",
+        "required": ["activities"],
+        "properties": {
+          "activities": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Activity" }
+          }
+        }
+      },
+      "CommentRequest": {
+        "type": "object",
+        "required": ["comment"],
+        "properties": {
+          "comment": {
+            "type": "object",
+            "required": ["author", "msg"],
+            "properties": {
+              "author": { "type": "string" },
+              "msg": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "BlogRequest": {
+        "type": "object",
+        "required": ["blog"],
+        "properties": {
+          "blog": {
+            "type": "object",
+            "required": ["author", "title", "msg", "passphrase"],
+            "properties": {
+              "author": { "type": "string" },
+              "title": { "type": "string" },
+              "msg": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "passphrase": { "type": "string" }
+            }
+          }
+        }
+      },
+      "MatchResult": {
+        "type": "object",
+        "required": ["match", "group", "homeTeam", "awayTeam", "homeScore", "awayScore", "isSet"],
+        "properties": {
+          "match": { "type": "string", "examples": ["m1"] },
+          "group": { "$ref": "#/components/schemas/Group" },
+          "homeTeam": { "$ref": "#/components/schemas/Team" },
+          "awayTeam": { "$ref": "#/components/schemas/Team" },
+          "homeScore": { "type": "integer" },
+          "awayScore": { "type": "integer" },
+          "isSet": {
+            "type": "boolean",
+            "description": "When false the score fields are ignored by the client (treated as not-yet-entered)."
+          }
+        }
+      },
+      "MatchResults": {
+        "type": "object",
+        "required": ["results"],
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MatchResult" }
+          }
+        }
+      },
+      "TopscorerResultEntry": {
+        "type": "object",
+        "required": ["hasQualified", "topscorer"],
+        "properties": {
+          "hasQualified": { "$ref": "#/components/schemas/HasQualified" },
+          "topscorer": { "$ref": "#/components/schemas/Topscorer" }
+        }
+      },
+      "TopscorerResults": {
+        "type": "object",
+        "required": ["topscorers"],
+        "properties": {
+          "topscorers": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TopscorerResultEntry" }
+          }
+        }
+      },
+      "TeamRoundsEntry": {
+        "type": "object",
+        "required": ["team", "roundsQualified"],
+        "properties": {
+          "team": { "$ref": "#/components/schemas/Team" },
+          "roundsQualified": {
+            "type": "object",
+            "description": "Map from stringified round number (\"1\"-\"6\") to HasQualified.",
+            "additionalProperties": { "$ref": "#/components/schemas/HasQualified" }
+          }
+        }
+      },
+      "KnockoutsResults": {
+        "type": "object",
+        "required": ["teams"],
+        "properties": {
+          "teams": {
+            "type": "object",
+            "description": "Map keyed by teamID (lowercased, e.g. \"ned\") whose values describe that team's qualification per round.",
+            "additionalProperties": { "$ref": "#/components/schemas/TeamRoundsEntry" }
+          }
+        }
+      },
+      "RoundScore": {
+        "type": "object",
+        "required": ["round", "points"],
+        "properties": {
+          "round": { "type": "string" },
+          "points": { "type": "integer" }
+        }
+      },
+      "RankingSummaryLine": {
+        "type": "object",
+        "required": ["name", "rounds", "topscorer", "total", "uuid"],
+        "properties": {
+          "name": { "type": "string" },
+          "rounds": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RoundScore" }
+          },
+          "topscorer": { "type": "integer" },
+          "total": { "type": "integer" },
+          "uuid": { "type": "string" }
+        }
+      },
+      "RankingGroup": {
+        "type": "object",
+        "required": ["pos", "bets", "total"],
+        "properties": {
+          "pos": { "type": "integer" },
+          "bets": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RankingSummaryLine" }
+          },
+          "total": { "type": "integer" }
+        }
+      },
+      "RankingSummary": {
+        "type": "object",
+        "required": ["summary", "time"],
+        "properties": {
+          "summary": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RankingGroup" }
+          },
+          "time": {
+            "type": "integer",
+            "description": "Last-updated time as Unix epoch milliseconds."
+          }
+        }
+      },
+      "RankingDetails": {
+        "type": "object",
+        "required": ["name", "rounds", "topscorer", "total", "uuid", "bet"],
+        "properties": {
+          "name": { "type": "string" },
+          "rounds": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RoundScore" }
+          },
+          "topscorer": { "type": "integer" },
+          "total": { "type": "integer" },
+          "uuid": { "type": "string" },
+          "bet": { "$ref": "#/components/schemas/BetFlat" }
+        }
+      },
+      "AuthRequest": {
+        "type": "object",
+        "required": ["username", "password"],
+        "properties": {
+          "username": { "type": "string" },
+          "password": { "type": "string" }
+        }
+      },
+      "AuthResponse": {
+        "type": "object",
+        "required": ["token"],
+        "properties": {
+          "token": { "type": "string" }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/authentication/authentications": {
+      "post": {
+        "tags": ["Authentication"],
+        "summary": "Exchange credentials for a bearer token",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/AuthRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Authenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AuthResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/flat/": {
+      "post": {
+        "tags": ["Bets"],
+        "summary": "Create a bet (flat bracket format)",
+        "security": [],
+        "description": "Client POSTs without a uuid; server assigns one and echoes the bet back.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/BetFlat" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bet created",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BetFlat" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/flat/{uuid}": {
+      "parameters": [
+        {
+          "name": "uuid",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "tags": ["Bets"],
+        "summary": "Fetch a bet by uuid (flat format)",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Bet found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BetFlat" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Bets"],
+        "summary": "Update a bet (flat format)",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/BetFlat" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bet updated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BetFlat" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/": {
+      "get": {
+        "tags": ["Admin"],
+        "summary": "List all bets (summary form)",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Bet summaries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/BetSummaryLine" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/activate/{uuid}": {
+      "parameters": [
+        {
+          "name": "uuid",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "post": {
+        "tags": ["Admin"],
+        "summary": "Mark a bet active",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Bet activated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BetFlat" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/deactivate/{uuid}": {
+      "parameters": [
+        {
+          "name": "uuid",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "post": {
+        "tags": ["Admin"],
+        "summary": "Mark a bet inactive",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Bet deactivated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BetFlat" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities": {
+      "get": {
+        "tags": ["Activities"],
+        "summary": "Fetch the activity feed",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Activity list",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActivitiesResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities/comments": {
+      "post": {
+        "tags": ["Activities"],
+        "summary": "Post a comment (unauthenticated)",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CommentRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated activity list",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActivitiesResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities/blogs": {
+      "post": {
+        "tags": ["Activities"],
+        "summary": "Publish a blog post",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/BlogRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated activity list",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActivitiesResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/results/matches/": {
+      "get": {
+        "tags": ["Match results"],
+        "summary": "Fetch all match results",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Match results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MatchResults" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/results/matches/{matchId}": {
+      "parameters": [
+        {
+          "name": "matchId",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "put": {
+        "tags": ["Match results"],
+        "summary": "Update a single match result",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MatchResult" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated match results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MatchResults" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/results/matches/initial/": {
+      "post": {
+        "tags": ["Match results"],
+        "summary": "Seed the match results table (admin)",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MatchResults" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Seeded match results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MatchResults" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/results/topscorer/": {
+      "get": {
+        "tags": ["Topscorer results"],
+        "summary": "Fetch topscorer results",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Topscorer results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TopscorerResults" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Topscorer results"],
+        "summary": "Replace topscorer results",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/TopscorerResults" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated topscorer results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TopscorerResults" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/results/topscorer/initial/": {
+      "post": {
+        "tags": ["Topscorer results"],
+        "summary": "Seed topscorer results (admin)",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Seeded topscorer results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TopscorerResults" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/results/knockouts/": {
+      "get": {
+        "tags": ["Knockouts results"],
+        "summary": "Fetch knockout qualification per team",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Knockouts results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/KnockoutsResults" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Knockouts results"],
+        "summary": "Replace knockouts results",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/KnockoutsResults" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated knockouts results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/KnockoutsResults" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/results/knockouts/initial/": {
+      "post": {
+        "tags": ["Knockouts results"],
+        "summary": "Seed knockouts results (admin)",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Seeded knockouts results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/KnockoutsResults" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/ranking/": {
+      "get": {
+        "tags": ["Ranking"],
+        "summary": "Fetch the ranking summary",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Ranking summary",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RankingSummary" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/ranking/{uuid}": {
+      "parameters": [
+        {
+          "name": "uuid",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "tags": ["Ranking"],
+        "summary": "Fetch ranking details (including the bet) for one participant",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Ranking details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RankingDetails" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bets/ranking/initial/": {
+      "post": {
+        "tags": ["Ranking"],
+        "summary": "Recompute the ranking (admin)",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": { "type": ["object", "null"] }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Recomputed ranking summary",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RankingSummary" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/API/Bets.elm
+++ b/src/API/Bets.elm
@@ -1,15 +1,20 @@
 module API.Bets exposing
     ( createBet
     , createBetFlat
+    , createBetSimple
     , fetchBet
     , fetchBetFlat
+    , fetchBetSimple
     , placeBet
     , placeBetFlat
+    , placeBetSimple
     , updateBet
     , updateBetFlat
+    , updateBetSimple
     )
 
 import Bets.Bet
+import Bets.SimpleBet exposing (SimpleBet)
 import Bets.Types exposing (Bet)
 import RemoteData exposing (RemoteData(..))
 import RemoteData.Http as Http
@@ -64,6 +69,32 @@ createBetFlat bet =
 updateBetFlat : Bet -> String -> Cmd Msg
 updateBetFlat bet uuid =
     Http.put ("/bets/flat/" ++ uuid) SubmittedBet Bets.Bet.decodeFlat (Bets.Bet.encodeFlat bet)
+
+
+
+placeBetSimple : SimpleBet -> Cmd Msg
+placeBetSimple bet =
+    case bet.uuid of
+        Just uuid ->
+            updateBetSimple bet uuid
+
+        Nothing ->
+            createBetSimple bet
+
+
+fetchBetSimple : UUID -> Cmd Msg
+fetchBetSimple uuid =
+    Http.get ("/bets/simple/" ++ uuid) FetchedSimpleBet Bets.SimpleBet.decode
+
+
+createBetSimple : SimpleBet -> Cmd Msg
+createBetSimple bet =
+    Http.post "/bets/simple/" SubmittedSimpleBet Bets.SimpleBet.decode (Bets.SimpleBet.encode bet)
+
+
+updateBetSimple : SimpleBet -> String -> Cmd Msg
+updateBetSimple bet uuid =
+    Http.put ("/bets/simple/" ++ uuid) SubmittedSimpleBet Bets.SimpleBet.decode (Bets.SimpleBet.encode bet)
 
 
 

--- a/src/API/Bets.elm
+++ b/src/API/Bets.elm
@@ -1,6 +1,13 @@
-module API.Bets exposing (createBet, fetchBet, placeBet, updateBet)
-
--- import Http exposing (expectJson)
+module API.Bets exposing
+    ( createBet
+    , createBetFlat
+    , fetchBet
+    , fetchBetFlat
+    , placeBet
+    , placeBetFlat
+    , updateBet
+    , updateBetFlat
+    )
 
 import Bets.Bet
 import Bets.Types exposing (Bet)
@@ -11,32 +18,12 @@ import Types exposing (Msg(..), UUID)
 
 placeBet : Bet -> Cmd Msg
 placeBet bet =
-    -- let
-    --     ( vrb, url ) =
     case bet.uuid of
         Just uuid ->
             updateBet bet uuid
 
         Nothing ->
             createBet bet
-
-
-
---     body =
---         Bets.Bet.encode bet
---             |> Http.jsonBody
---     req =
---         Http.request
---             { method = vrb
---             , headers = []
---             , url = url
---             , body = body
---             , expect = expectJson Bets.Bet.decode
---             , timeout = Nothing
---             , withCredentials = False
---             }
--- in
--- Http.post msg req
 
 
 fetchBet : UUID -> Cmd Msg
@@ -52,6 +39,31 @@ createBet bet =
 updateBet : Bet -> String -> Cmd Msg
 updateBet bet uuid =
     Http.put ("/bets/" ++ uuid) SubmittedBet Bets.Bet.decode (Bets.Bet.encode bet)
+
+
+placeBetFlat : Bet -> Cmd Msg
+placeBetFlat bet =
+    case bet.uuid of
+        Just uuid ->
+            updateBetFlat bet uuid
+
+        Nothing ->
+            createBetFlat bet
+
+
+fetchBetFlat : UUID -> Cmd Msg
+fetchBetFlat uuid =
+    Http.get ("/bets/flat/" ++ uuid) FetchedBet Bets.Bet.decodeFlat
+
+
+createBetFlat : Bet -> Cmd Msg
+createBetFlat bet =
+    Http.post "/bets/flat/" SubmittedBet Bets.Bet.decodeFlat (Bets.Bet.encodeFlat bet)
+
+
+updateBetFlat : Bet -> String -> Cmd Msg
+updateBetFlat bet uuid =
+    Http.put ("/bets/flat/" ++ uuid) SubmittedBet Bets.Bet.decodeFlat (Bets.Bet.encodeFlat bet)
 
 
 

--- a/src/Bets/Bet.elm
+++ b/src/Bets/Bet.elm
@@ -2,10 +2,11 @@ module Bets.Bet exposing
     ( cleanThirds
     , decode
     , decodeBet
+    , decodeBetFlat
+    , decodeFlat
     , encode
-      -- , findAllGroupMatchAnswers
+    , encodeFlat
     , findGroupMatchAnswers
-      -- , getAnswer
     , getBracket
     , getTopscorer
     , isComplete
@@ -143,6 +144,44 @@ decodeBet : Decoder Bet
 decodeBet =
     Json.Decode.map4 Bet
         (field "answers" A.decode)
+        (field "uuid" (maybe Json.Decode.string))
+        (field "active" Json.Decode.bool)
+        (field "participant" Participant.decode)
+
+
+encodeFlat : Bet -> Json.Encode.Value
+encodeFlat bet =
+    let
+        betObject =
+            Json.Encode.object
+                [ ( "answers", A.encodeFlat bet.answers )
+                , ( "uuid", mStrEnc bet.uuid )
+                , ( "active", Json.Encode.bool bet.active )
+                , ( "participant", Participant.encode bet.participant )
+                ]
+    in
+    Json.Encode.object
+        [ ( "bet", betObject ) ]
+
+
+decodeFlat : Decoder Bet
+decodeFlat =
+    Json.Decode.map
+        (\x -> x.bet)
+        decodeIncomingFlat
+
+
+decodeIncomingFlat : Decoder IncomingBet
+decodeIncomingFlat =
+    Json.Decode.map
+        IncomingBet
+        (field "bet" decodeBetFlat)
+
+
+decodeBetFlat : Decoder Bet
+decodeBetFlat =
+    Json.Decode.map4 Bet
+        (field "answers" A.decodeFlat)
         (field "uuid" (maybe Json.Decode.string))
         (field "active" Json.Decode.bool)
         (field "participant" Participant.decode)

--- a/src/Bets/SimpleBet.elm
+++ b/src/Bets/SimpleBet.elm
@@ -1,0 +1,87 @@
+module Bets.SimpleBet exposing
+    ( SimpleBet
+    , SimpleAnswers
+    , decode
+    , decodeBet
+    , encode
+    , isComplete
+    )
+
+import Bets.Json.Encode exposing (mStrEnc)
+import Bets.Types exposing (AnswerGroupMatches, AnswerTopscorer, Participant)
+import Bets.Types.Answer.GroupMatches as GroupMatches
+import Bets.Types.Answer.SimpleBracket as SBracket
+import Bets.Types.Answer.Topscorer as Topscorer
+import Bets.Types.Participant as Participant
+import Bool.Extra as Bool
+import Json.Decode exposing (Decoder, field, maybe)
+import Json.Encode
+
+
+type alias SimpleAnswers =
+    { matches : AnswerGroupMatches
+    , bracket : SBracket.AnswerSimpleBracket
+    , topscorer : AnswerTopscorer
+    }
+
+
+type alias SimpleBet =
+    { answers : SimpleAnswers
+    , uuid : Maybe String
+    , active : Bool
+    , participant : Participant
+    }
+
+
+isComplete : SimpleBet -> Bool
+isComplete bet =
+    Bool.all
+        [ GroupMatches.isComplete bet.answers.matches
+        , Topscorer.isComplete bet.answers.topscorer
+        , SBracket.isComplete bet.answers.bracket
+        , Participant.isComplete bet.participant
+        ]
+
+
+encode : SimpleBet -> Json.Encode.Value
+encode bet =
+    let
+        answersJson =
+            Json.Encode.object
+                [ ( "matches", GroupMatches.encode bet.answers.matches )
+                , ( "bracket", SBracket.encode bet.answers.bracket )
+                , ( "topscorer", Topscorer.encode bet.answers.topscorer )
+                ]
+
+        betObject =
+            Json.Encode.object
+                [ ( "answers", answersJson )
+                , ( "uuid", mStrEnc bet.uuid )
+                , ( "active", Json.Encode.bool bet.active )
+                , ( "participant", Participant.encode bet.participant )
+                ]
+    in
+    Json.Encode.object
+        [ ( "bet", betObject ) ]
+
+
+decode : Decoder SimpleBet
+decode =
+    field "bet" decodeBet
+
+
+decodeBet : Decoder SimpleBet
+decodeBet =
+    Json.Decode.map4 SimpleBet
+        (field "answers" decodeAnswers)
+        (field "uuid" (maybe Json.Decode.string))
+        (field "active" Json.Decode.bool)
+        (field "participant" Participant.decode)
+
+
+decodeAnswers : Decoder SimpleAnswers
+decodeAnswers =
+    Json.Decode.map3 SimpleAnswers
+        (field "matches" GroupMatches.decode)
+        (field "bracket" SBracket.decode)
+        (field "topscorer" Topscorer.decode)

--- a/src/Bets/Types/Answer/Bracket.elm
+++ b/src/Bets/Types/Answer/Bracket.elm
@@ -1,7 +1,9 @@
 module Bets.Types.Answer.Bracket exposing
     ( cleanThirds
     , decode
+    , decodeFlat
     , encode
+    , encodeFlat
     , isComplete
     , isCompleteQualifiers
     , setQualifier
@@ -130,4 +132,19 @@ decode : Decoder AnswerBracket
 decode =
     Decode.succeed Answer
         |> required "bracket" Bets.Types.Bracket.decode
+        |> required "points" Bets.Types.Points.decode
+
+
+encodeFlat : AnswerBracket -> Json.Encode.Value
+encodeFlat (Answer bracket points) =
+    Json.Encode.object
+        [ ( "bracket", Bets.Types.Bracket.encodeFlat bracket )
+        , ( "points", Bets.Types.Points.encode points )
+        ]
+
+
+decodeFlat : Decoder AnswerBracket
+decodeFlat =
+    Decode.succeed Answer
+        |> required "bracket" Bets.Types.Bracket.decodeFlat
         |> required "points" Bets.Types.Points.decode

--- a/src/Bets/Types/Answer/SimpleBracket.elm
+++ b/src/Bets/Types/Answer/SimpleBracket.elm
@@ -1,0 +1,37 @@
+module Bets.Types.Answer.SimpleBracket exposing
+    ( AnswerSimpleBracket
+    , decode
+    , encode
+    , isComplete
+    )
+
+import Bets.Types exposing (Answer(..))
+import Bets.Types.Points
+import Bets.Types.SimpleBracket as SB
+import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline exposing (required)
+import Json.Encode
+
+
+type alias AnswerSimpleBracket =
+    Answer SB.SimpleBracket
+
+
+isComplete : AnswerSimpleBracket -> Bool
+isComplete (Answer bracket _) =
+    SB.isComplete bracket
+
+
+encode : AnswerSimpleBracket -> Json.Encode.Value
+encode (Answer bracket points) =
+    Json.Encode.object
+        [ ( "bracket", SB.encode bracket )
+        , ( "points", Bets.Types.Points.encode points )
+        ]
+
+
+decode : Decoder AnswerSimpleBracket
+decode =
+    Decode.succeed Answer
+        |> required "bracket" SB.decode
+        |> required "points" Bets.Types.Points.decode

--- a/src/Bets/Types/Answers.elm
+++ b/src/Bets/Types/Answers.elm
@@ -1,7 +1,9 @@
 module Bets.Types.Answers exposing
     ( cleanThirds
     , decode
+    , decodeFlat
     , encode
+    , encodeFlat
     , setQualifier
     , setScore
     , setTopscorer
@@ -60,4 +62,21 @@ decode =
     Decode.succeed Answers
         |> required "matches" Gm.decode
         |> required "bracket" Br.decode
+        |> required "topscorer" Ts.decode
+
+
+encodeFlat : Answers -> Json.Encode.Value
+encodeFlat answers =
+    Json.Encode.object
+        [ ( "matches", Gm.encode answers.matches )
+        , ( "bracket", Br.encodeFlat answers.bracket )
+        , ( "topscorer", Ts.encode answers.topscorer )
+        ]
+
+
+decodeFlat : Decoder Answers
+decodeFlat =
+    Decode.succeed Answers
+        |> required "matches" Gm.decode
+        |> required "bracket" Br.decodeFlat
         |> required "topscorer" Ts.decode

--- a/src/Bets/Types/Bracket.elm
+++ b/src/Bets/Types/Bracket.elm
@@ -2,9 +2,11 @@ module Bets.Types.Bracket exposing
     ( candidatesForSlot
     , candidatesForTeamNode
     , decode
+    , decodeFlat
     , decodeWinner
     , display
     , encode
+    , encodeFlat
     , get
     , getFreeSlots
     , getQualifiers
@@ -21,15 +23,16 @@ module Bets.Types.Bracket exposing
     , winner
     )
 
-import Bets.Types exposing (Bracket(..), Candidate, CurrentSlot(..), Group, HasQualified(..), Qualifier, Selection, Slot, Team, Winner(..))
+import Bets.Types exposing (Bracket(..), Candidate, CurrentSlot(..), Group, HasQualified(..), Qualifier, Round, Selection, Slot, Team, Winner(..))
 import Bets.Types.Candidate as C
 import Bets.Types.HasQualified as HasQualified
 import Bets.Types.Round as R
 import Bets.Types.Team as T
-import Dict
+import Dict exposing (Dict)
 import Json.Decode exposing (Decoder, fail, field, lazy, maybe)
 import Json.Encode
 import Maybe.Extra as M
+import Set
 
 
 hasQualified : Bracket -> HasQualified
@@ -430,3 +433,166 @@ decodeWinner w =
 
         Just wnr ->
             Json.Decode.succeed (stringToWinner wnr)
+
+
+
+-- FLAT JSON
+
+
+nodeSlot : Bracket -> Slot
+nodeSlot br =
+    case br of
+        TeamNode s _ _ _ ->
+            s
+
+        MatchNode s _ _ _ _ _ ->
+            s
+
+
+encodeFlat : Bracket -> Json.Encode.Value
+encodeFlat bracket =
+    Json.Encode.object
+        [ ( "nodes", Json.Encode.list encodeFlatNode (flatten bracket) ) ]
+
+
+flatten : Bracket -> List Bracket
+flatten bracket =
+    case bracket of
+        TeamNode _ _ _ _ ->
+            [ bracket ]
+
+        MatchNode _ _ home away _ _ ->
+            bracket :: flatten home ++ flatten away
+
+
+encodeFlatNode : Bracket -> Json.Encode.Value
+encodeFlatNode bracket =
+    case bracket of
+        TeamNode slot cand qual hasQ ->
+            Json.Encode.object
+                [ ( "kind", Json.Encode.string "team" )
+                , ( "slot", Json.Encode.string slot )
+                , ( "candidate", C.encode cand )
+                , ( "qualifier", T.encodeMaybe qual )
+                , ( "hasQualified", HasQualified.encode hasQ )
+                ]
+
+        MatchNode slot wnnr home away round hasQ ->
+            Json.Encode.object
+                [ ( "kind", Json.Encode.string "match" )
+                , ( "slot", Json.Encode.string slot )
+                , ( "round", R.encode round )
+                , ( "home", Json.Encode.string (nodeSlot home) )
+                , ( "away", Json.Encode.string (nodeSlot away) )
+                , ( "winner", encodeWinner wnnr )
+                , ( "winningTeam", T.encodeMaybe (winner bracket) )
+                , ( "hasQualified", HasQualified.encode hasQ )
+                ]
+
+
+type FlatNode
+    = FlatTeam Slot Candidate Qualifier HasQualified
+    | FlatMatch Slot Round Slot Slot Winner HasQualified
+
+
+flatNodeSlot : FlatNode -> Slot
+flatNodeSlot node =
+    case node of
+        FlatTeam s _ _ _ ->
+            s
+
+        FlatMatch s _ _ _ _ _ ->
+            s
+
+
+decodeFlat : Decoder Bracket
+decodeFlat =
+    field "nodes" (Json.Decode.list decodeFlatNode)
+        |> Json.Decode.andThen
+            (\nodes ->
+                case rebuildTree nodes of
+                    Ok br ->
+                        Json.Decode.succeed br
+
+                    Err e ->
+                        fail e
+            )
+
+
+decodeFlatNode : Decoder FlatNode
+decodeFlatNode =
+    field "kind" Json.Decode.string
+        |> Json.Decode.andThen
+            (\kind ->
+                case kind of
+                    "team" ->
+                        Json.Decode.map4 FlatTeam
+                            (field "slot" Json.Decode.string)
+                            (field "candidate" C.decode)
+                            (field "qualifier" (maybe T.decode))
+                            (field "hasQualified" HasQualified.decode)
+
+                    "match" ->
+                        Json.Decode.map6 FlatMatch
+                            (field "slot" Json.Decode.string)
+                            (field "round" R.decode)
+                            (field "home" Json.Decode.string)
+                            (field "away" Json.Decode.string)
+                            (field "winner" (maybe Json.Decode.string |> Json.Decode.andThen decodeWinner))
+                            (field "hasQualified" HasQualified.decode)
+
+                    _ ->
+                        fail (kind ++ " is not a recognized flat bracket node kind")
+            )
+
+
+rebuildTree : List FlatNode -> Result String Bracket
+rebuildTree nodes =
+    let
+        bySlot : Dict Slot FlatNode
+        bySlot =
+            nodes
+                |> List.map (\n -> ( flatNodeSlot n, n ))
+                |> Dict.fromList
+
+        childSlots =
+            nodes
+                |> List.concatMap
+                    (\n ->
+                        case n of
+                            FlatMatch _ _ h a _ _ ->
+                                [ h, a ]
+
+                            FlatTeam _ _ _ _ ->
+                                []
+                    )
+                |> Set.fromList
+
+        roots =
+            List.filter (\n -> not (Set.member (flatNodeSlot n) childSlots)) nodes
+    in
+    case roots of
+        [ root ] ->
+            buildFrom bySlot (flatNodeSlot root)
+
+        [] ->
+            Err "flat bracket has no root node"
+
+        _ ->
+            Err "flat bracket has multiple root nodes"
+
+
+buildFrom : Dict Slot FlatNode -> Slot -> Result String Bracket
+buildFrom bySlot slot =
+    case Dict.get slot bySlot of
+        Nothing ->
+            Err ("flat bracket references unknown slot: " ++ slot)
+
+        Just (FlatTeam s cand qual hasQ) ->
+            Ok (TeamNode s cand qual hasQ)
+
+        Just (FlatMatch s round homeSlot awaySlot wnnr hasQ) ->
+            Result.map2
+                (\h a -> MatchNode s wnnr h a round hasQ)
+                (buildFrom bySlot homeSlot)
+                (buildFrom bySlot awaySlot)

--- a/src/Bets/Types/SimpleBracket.elm
+++ b/src/Bets/Types/SimpleBracket.elm
@@ -1,0 +1,124 @@
+module Bets.Types.SimpleBracket exposing
+    ( SimpleBracket
+    , SimpleBracketEntry
+    , decode
+    , encode
+    , isComplete
+    )
+
+import Bets.Types exposing (HasQualified(..), Round(..), Team)
+import Bets.Types.HasQualified as HasQualified
+import Bets.Types.Round as Round
+import Bets.Types.Team as Team
+import Json.Decode exposing (Decoder)
+import Json.Decode.Pipeline exposing (required)
+import Json.Encode
+import List.Extra
+
+
+type alias SimpleBracketEntry =
+    { team : Team
+    , round : Round
+    , hasQualified : HasQualified
+    }
+
+
+type alias SimpleBracket =
+    List SimpleBracketEntry
+
+
+roundRequired : Round -> Int
+roundRequired round =
+    case round of
+        R1 ->
+            32
+
+        R2 ->
+            16
+
+        R3 ->
+            8
+
+        R4 ->
+            4
+
+        R5 ->
+            2
+
+        R6 ->
+            1
+
+
+allRounds : List Round
+allRounds =
+    [ R1, R2, R3, R4, R5, R6 ]
+
+
+teamsInRound : Round -> SimpleBracket -> List Team
+teamsInRound round bracket =
+    bracket
+        |> List.filter (\e -> e.round == round)
+        |> List.map .team
+
+
+isComplete : SimpleBracket -> Bool
+isComplete bracket =
+    let
+        roundComplete round =
+            let
+                teams =
+                    List.Extra.uniqueBy .teamID (teamsInRound round bracket)
+            in
+            List.length teams == roundRequired round
+
+        progressionOk round =
+            let
+                roundInt =
+                    Round.toInt round
+            in
+            if roundInt == 1 then
+                True
+
+            else
+                let
+                    teamsHere =
+                        List.Extra.uniqueBy .teamID (teamsInRound round bracket)
+
+                    prevTeams =
+                        teamsInRound (Round.fromInt (roundInt - 1)) bracket
+                in
+                List.all (\t -> List.any (\pt -> pt.teamID == t.teamID) prevTeams) teamsHere
+    in
+    List.all (\r -> roundComplete r && progressionOk r) allRounds
+
+
+
+-- JSON
+
+
+encode : SimpleBracket -> Json.Encode.Value
+encode bracket =
+    Json.Encode.object
+        [ ( "entries", Json.Encode.list encodeEntry bracket ) ]
+
+
+encodeEntry : SimpleBracketEntry -> Json.Encode.Value
+encodeEntry entry =
+    Json.Encode.object
+        [ ( "team", Team.encode entry.team )
+        , ( "round", Round.encode entry.round )
+        , ( "hasQualified", HasQualified.encode entry.hasQualified )
+        ]
+
+
+decode : Decoder SimpleBracket
+decode =
+    Json.Decode.field "entries" (Json.Decode.list decodeEntry)
+
+
+decodeEntry : Decoder SimpleBracketEntry
+decodeEntry =
+    Json.Decode.succeed SimpleBracketEntry
+        |> required "team" Team.decode
+        |> required "round" Round.decode
+        |> required "hasQualified" HasQualified.decode

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -317,7 +317,7 @@ update msg model =
         SubmitMsg ->
             let
                 cmd =
-                    API.Bets.placeBet model.bet
+                    API.Bets.placeBetFlat model.bet
             in
             ( model, cmd )
 
@@ -1009,7 +1009,7 @@ update msg model =
         BetSelected uuid ->
             let
                 cmd =
-                    API.Bets.fetchBet uuid
+                    API.Bets.fetchBetFlat uuid
             in
             ( model, cmd )
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -406,6 +406,12 @@ update msg model =
         FetchedBet bet ->
             ( { model | savedBet = bet }, Cmd.none )
 
+        SubmittedSimpleBet _ ->
+            ( model, Cmd.none )
+
+        FetchedSimpleBet _ ->
+            ( model, Cmd.none )
+
         SetCommentMsg newMessage ->
             let
                 oldComment =

--- a/src/Results/Bets.elm
+++ b/src/Results/Bets.elm
@@ -42,7 +42,7 @@ toggleActive (Token token) uid toggle =
                 ToggleInactive ->
                     "/bets/deactivate/" ++ uid
     in
-    Web.postWithConfig config path ToggledBetActiveFlag Bets.Bet.decodeBet Json.Encode.null
+    Web.postWithConfig config path ToggledBetActiveFlag Bets.Bet.decodeFlat Json.Encode.null
 
 
 view : Model Msg -> Element.Element Msg

--- a/src/Results/Ranking.elm
+++ b/src/Results/Ranking.elm
@@ -205,7 +205,7 @@ decodeRankingDetails =
         (field "topscorer" Json.Decode.int)
         (field "total" Json.Decode.int)
         (field "uuid" Json.Decode.string)
-        (field "bet" Bets.Bet.decodeBet)
+        (field "bet" Bets.Bet.decodeBetFlat)
 
 
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -38,6 +38,7 @@ module Types exposing
     )
 
 import Bets.Init
+import Bets.SimpleBet exposing (SimpleBet)
 import Bets.Types exposing (Bet, Group(..), Round(..), Topscorer)
 import Browser
 import Browser.Navigation as Navigation
@@ -196,6 +197,8 @@ type Msg
     | SubmittedBet (WebData Bet)
     | BetSelected UUID
     | FetchedBet (WebData Bet)
+    | SubmittedSimpleBet (WebData SimpleBet)
+    | FetchedSimpleBet (WebData SimpleBet)
     | NoOp
     | Restart
     | UrlRequest Browser.UrlRequest


### PR DESCRIPTION
## Summary

- Adds `SimpleBracket` — a flat list-based bracket representation as an alternative to the existing tree-based `Bracket` type
- Each `SimpleBracketEntry` holds `{ team, round, hasQualified }` using the existing `Round` (R1–R6) and `HasQualified` types; R6 is the champion slot
- Completeness check enforces exact unique team counts per round (32/16/8/4/2/1) and upward progression invariants (all teams in round N must appear in round N-1)
- `SimpleBet` is a fully separate parallel type to `Bet` — no changes to existing `Bet`, `Answers`, or bracket code
- API functions target `/bets/simple/<uuid>` (create, update, fetch, place)
- Also includes the prior flat wire format migration (`feat: migrate bet/bracket API to flat wire format`)

## New files

| File | Purpose |
|---|---|
| `src/Bets/Types/SimpleBracket.elm` | `SimpleBracketEntry`, `SimpleBracket`, `isComplete`, encode/decode |
| `src/Bets/Types/Answer/SimpleBracket.elm` | `AnswerSimpleBracket`, encode/decode, `isComplete` |
| `src/Bets/SimpleBet.elm` | `SimpleAnswers`, `SimpleBet`, `isComplete`, encode/decode |

## Test plan

- [ ] Project compiles cleanly (`make debug`)
- [ ] `SimpleBracket.isComplete` returns `False` when any round has wrong team count
- [ ] `SimpleBracket.isComplete` returns `False` when a team appears in a higher round but not the lower one
- [ ] `SimpleBet.encode` / `SimpleBet.decode` round-trip correctly (outer `{"bet": ...}` wrapper preserved)
- [ ] `SimpleBet.decodeBet` decodes inner bet object without wrapper (matches `Bets.Bet.decodeBetFlat` pattern)
- [ ] API endpoints compile and call correct URLs (`/bets/simple/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)