### PR TITLE
feat: SimpleBracket UI form and test data cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ errors
 .gemini/
 gha-creds-*.json
 .superpowers/
+.worktrees/

--- a/src/Bets/Init.elm
+++ b/src/Bets/Init.elm
@@ -1,4 +1,4 @@
-module Bets.Init exposing (answers, bet, groupMembers, groupsAndFirstMatch, matches, teamData)
+module Bets.Init exposing (answers, bet, groupMembers, groupsAndFirstMatch, matches, simpleBet, teamData)
 
 -- To add a tournament: add a Bets.Init.<yourtournament>.Tournament module
 -- and have it expose the three functions (bracket, initTeamData, matches)
@@ -10,6 +10,7 @@ module Bets.Init exposing (answers, bet, groupMembers, groupsAndFirstMatch, matc
 
 import Bets.Init.Lib as Init
 import Bets.Init.WorldCup2026.Tournament as Tournament
+import Bets.SimpleBet exposing (SimpleBet, SimpleAnswers)
 import Bets.Types exposing (Answer(..), AnswerGroupMatches, Answers, Bet, Group(..), GroupMatch(..), Team)
 import Bets.Types.Match as Match
 import Bets.Types.Participant as Participant
@@ -40,6 +41,23 @@ matches =
 bet : Bet
 bet =
     { answers = answers
+    , uuid = Nothing
+    , active = True
+    , participant = Participant.init
+    }
+
+
+simpleAnswers : SimpleAnswers
+simpleAnswers =
+    { matches = initMatches
+    , bracket = Answer [] Nothing
+    , topscorer = Init.answerTopscorer
+    }
+
+
+simpleBet : SimpleBet
+simpleBet =
+    { answers = simpleAnswers
     , uuid = Nothing
     , active = True
     , participant = Participant.init

--- a/src/Bets/SimpleBet.elm
+++ b/src/Bets/SimpleBet.elm
@@ -4,15 +4,22 @@ module Bets.SimpleBet exposing
     , decode
     , decodeBet
     , encode
+    , getSimpleBracket
+    , getTopscorer
     , isComplete
+    , setMatchScore
+    , setParticipant
+    , setTopscorer
+    , updateSimpleBracket
     )
 
 import Bets.Json.Encode exposing (mStrEnc)
-import Bets.Types exposing (AnswerGroupMatches, AnswerTopscorer, Participant)
+import Bets.Types exposing (Answer(..), AnswerGroupMatches, AnswerTopscorer, MatchID, Participant, Score, Topscorer)
 import Bets.Types.Answer.GroupMatches as GroupMatches
 import Bets.Types.Answer.SimpleBracket as SBracket
 import Bets.Types.Answer.Topscorer as Topscorer
 import Bets.Types.Participant as Participant
+import Bets.Types.SimpleBracket exposing (SimpleBracket)
 import Bool.Extra as Bool
 import Json.Decode exposing (Decoder, field, maybe)
 import Json.Encode
@@ -31,6 +38,68 @@ type alias SimpleBet =
     , active : Bool
     , participant : Participant
     }
+
+
+setMatchScore : SimpleBet -> MatchID -> Score -> SimpleBet
+setMatchScore bet matchID score =
+    let
+        oldAnswers =
+            bet.answers
+
+        newMatches =
+            GroupMatches.setScore oldAnswers.matches matchID score
+    in
+    { bet | answers = { oldAnswers | matches = newMatches } }
+
+
+setTopscorer : SimpleBet -> Topscorer -> SimpleBet
+setTopscorer bet topscorer =
+    let
+        oldAnswers =
+            bet.answers
+
+        newTopscorer =
+            Topscorer.set oldAnswers.topscorer topscorer
+    in
+    { bet | answers = { oldAnswers | topscorer = newTopscorer } }
+
+
+getTopscorer : SimpleBet -> Topscorer
+getTopscorer bet =
+    let
+        (Answer topscorer _) =
+            bet.answers.topscorer
+    in
+    topscorer
+
+
+setParticipant : SimpleBet -> Participant -> SimpleBet
+setParticipant bet participant =
+    { bet | participant = participant }
+
+
+getSimpleBracket : SimpleBet -> SimpleBracket
+getSimpleBracket bet =
+    let
+        (Answer bracket _) =
+            bet.answers.bracket
+    in
+    bracket
+
+
+updateSimpleBracket : SimpleBet -> SimpleBracket -> SimpleBet
+updateSimpleBracket bet newBracket =
+    let
+        oldAnswers =
+            bet.answers
+
+        (Answer _ points) =
+            oldAnswers.bracket
+
+        newBracketAnswer =
+            Answer newBracket points
+    in
+    { bet | answers = { oldAnswers | bracket = newBracketAnswer } }
 
 
 isComplete : SimpleBet -> Bool

--- a/src/Bets/Types/SimpleBracket.elm
+++ b/src/Bets/Types/SimpleBracket.elm
@@ -4,6 +4,7 @@ module Bets.Types.SimpleBracket exposing
     , decode
     , encode
     , isComplete
+    , teamsInRound
     )
 
 import Bets.Types exposing (HasQualified(..), Round(..), Team)

--- a/src/Bets/View.elm
+++ b/src/Bets/View.elm
@@ -1,10 +1,14 @@
 module Bets.View exposing (view, viewBet)
 
+import Bets.SimpleBet exposing (SimpleBet)
 import Bets.Types exposing (..)
 import Bets.Types.Answer.GroupMatch as GM
 import Bets.Types.Bracket as B
+import Bets.Types.Round as Round
 import Bets.Types.Score as S
+import Bets.Types.SimpleBracket as SB
 import Bets.Types.StringField as StringField
+import Bets.Types.Team as T
 import Bets.View.Bracket
 import Element exposing (Element, centerX, centerY, height, padding, paddingEach, paddingXY, px, spacing, spacingXY, width)
 import Element.Background as Background
@@ -34,22 +38,30 @@ view model =
             Element.text "Aan het ophalen..."
 
         Failure _ ->
-            -- let
-            --     t =
-            --         Debug.log "error! " err
-            -- in
             UI.Text.error "Oeps. Daar ging iets niet goed."
 
         Success bet ->
-            viewBet bet model.screen
+            viewSimpleBet bet model.screen
+
+
+viewSimpleBet : SimpleBet -> Screen.Size -> Element.Element Msg
+viewSimpleBet bet screenSize =
+    Element.column
+        [ spacing 40, Element.width Element.fill ]
+        [ displayParticipant bet.participant
+        , UI.Text.displayHeader "Het Schema"
+        , displaySimpleBracket bet
+        , UI.Text.displayHeader "De Topscorer"
+        , topscorerIntro
+        , displayTopscorer bet.answers.topscorer
+        , UI.Text.displayHeader "De wedstrijden"
+        , matchesIntro
+        , displayMatches bet.answers.matches
+        ]
 
 
 viewBet : Bet -> Screen.Size -> Element.Element Msg
 viewBet bet screenSize =
-    let
-        device =
-            Screen.device screenSize
-    in
     Element.column
         [ spacing 40, Element.width Element.fill ]
         [ displayParticipant bet.participant
@@ -61,6 +73,31 @@ viewBet bet screenSize =
         , UI.Text.displayHeader "De wedstrijden"
         , matchesIntro
         , displayMatches bet.answers.matches
+        ]
+
+
+displayBracket : Screen.Size -> Bet -> Element.Element Msg
+displayBracket screen bet =
+    let
+        br =
+            bet.answers.bracket
+
+        introtext =
+            """Dit is het schema voor de tweede ronde en verder. In het midden staat de finale en de kampioen,
+         daarboven en onder de ronden die daaraan voorafgaan. Voor ieder team dat je juist hebt in de tweede
+         ronde krijg je 1 punt. Voor de juiste kwartfinalisten krijg je 4 punten. Halve finalisten leveren 7
+         punten op, finalisten 10 punten en de kampioen 13 punten."""
+
+        introduction =
+            Element.paragraph [ paddingEach { top = 0, right = 0, bottom = 32, left = 0 } ] [ UI.Text.simpleText introtext ]
+
+        rings (Answer brkt _) =
+            Bets.View.Bracket.viewRings bet brkt screen
+    in
+    Element.column
+        [ spacing 20 ]
+        [ introduction
+        , rings br
         ]
 
 
@@ -126,29 +163,62 @@ displayMatch ( _, Answer groupMatch pts ) =
     disp groupMatch
 
 
-displayBracket : Screen.Size -> Bet -> Element.Element Msg
-displayBracket screen bet =
+displaySimpleBracket : SimpleBet -> Element.Element Msg
+displaySimpleBracket bet =
     let
-        br =
+        (Answer bracket _) =
             bet.answers.bracket
 
         introtext =
-            """Dit is het schema voor de tweede ronde en verder. In het midden staat de finale en de kampioen,
-         daarboven en onder de ronden die daaraan voorafgaan. Voor ieder team dat je juist hebt in de tweede
+            """Dit is het schema voor de tweede ronde en verder. Voor ieder team dat je juist hebt in de tweede
          ronde krijg je 1 punt. Voor de juiste kwartfinalisten krijg je 4 punten. Halve finalisten leveren 7
          punten op, finalisten 10 punten en de kampioen 13 punten."""
 
         introduction =
             Element.paragraph [ paddingEach { top = 0, right = 0, bottom = 32, left = 0 } ] [ UI.Text.simpleText introtext ]
 
-        rings (Answer brkt _) =
-            Bets.View.Bracket.viewRings bet brkt screen
+        allRounds =
+            [ R1, R2, R3, R4, R5, R6 ]
+
+        roundLabel r =
+            case r of
+                R1 -> "R32"
+                R2 -> "R16"
+                R3 -> "KF"
+                R4 -> "HF"
+                R5 -> "F"
+                R6 -> "Kampioen"
+
+        viewRoundRow r =
+            let
+                teams =
+                    SB.teamsInRound r bracket
+                        |> List.sortBy .teamName
+
+                teamNames =
+                    List.map T.display teams
+                        |> String.join ", "
+            in
+            Element.row
+                [ spacing 8, Element.width Element.fill ]
+                [ Element.el
+                    [ Font.color Color.grey
+                    , UI.Font.mono
+                    , Font.size UI.Font.captionSize
+                    , Element.width (Element.px 80)
+                    ]
+                    (Element.text (roundLabel r))
+                , Element.paragraph
+                    [ Font.color Color.primaryText
+                    , UI.Font.mono
+                    , Font.size UI.Font.captionSize
+                    ]
+                    [ Element.text teamNames ]
+                ]
     in
     Element.column
-        [ spacing 20 ]
-        [ introduction
-        , rings br
-        ]
+        [ spacing 8 ]
+        (introduction :: List.map viewRoundRow allRounds)
 
 
 displayTopscorer : Answer Topscorer -> Element.Element Msg

--- a/src/Form/Card.elm
+++ b/src/Form/Card.elm
@@ -1,9 +1,10 @@
-module Form.Card exposing (findByCardId, getBracketCard, getGroupMatchesCard, getParticipantCard, update, updateBracketCard, updateGroupMatchesCard, updateParticipantCard, updateScreenCard, updateScreenCards)
+module Form.Card exposing (findByCardId, getBracketCard, getGroupMatchesCard, getParticipantCard, getSimpleBracketCard, update, updateBracketCard, updateGroupMatchesCard, updateParticipantCard, updateScreenCard, updateScreenCards, updateSimpleBracketCard)
 
 import Bets.Types exposing (Round(..))
 import Form.Bracket.Types as Bracket
 import Form.GroupMatches.Types as GroupMatches
 import Form.Participant.Types as Participant
+import Form.SimpleBracket.Types as SimpleBracket
 import Types exposing (Card(..), Info(..))
 import UI.Screen as Screen
 
@@ -150,11 +151,43 @@ updateScreenCards sz crds =
     List.map (updateScreenCard sz) crds
 
 
+getSimpleBracketCard : List Card -> Maybe Card
+getSimpleBracketCard cards =
+    List.filterMap
+        (\c ->
+            case c of
+                SimpleBracketCard _ ->
+                    Just c
+
+                _ ->
+                    Nothing
+        )
+        cards
+        |> List.head
+
+
+updateSimpleBracketCard : List Card -> SimpleBracket.State -> List Card
+updateSimpleBracketCard cards newState =
+    List.map
+        (\c ->
+            case c of
+                SimpleBracketCard _ ->
+                    SimpleBracketCard newState
+
+                _ ->
+                    c
+        )
+        cards
+
+
 updateScreenCard : Screen.Size -> Card -> Card
 updateScreenCard sz card =
     case card of
         BracketCard { bracketState } ->
             BracketCard <| Bracket.State sz bracketState
+
+        SimpleBracketCard state ->
+            SimpleBracketCard { state | screen = sz }
 
         _ ->
             card

--- a/src/Form/Dashboard.elm
+++ b/src/Form/Dashboard.elm
@@ -8,9 +8,9 @@ import Element.Background as Background
 import Element.Border as Border
 import Element.Events
 import Element.Font as Font
-import Form.Bracket
 import Form.GroupMatches
 import Form.Participant
+import Form.SimpleBracket
 import Form.Topscorer
 import Types exposing (Card(..), Model, Msg(..))
 import UI.Color as Color
@@ -39,7 +39,7 @@ view model =
             findCardIndex
                 (\c ->
                     case c of
-                        BracketCard _ ->
+                        SimpleBracketCard _ ->
                             True
 
                         _ ->
@@ -78,7 +78,7 @@ view model =
             Form.GroupMatches.isComplete model.bet
 
         bracketComplete =
-            Form.Bracket.isCompleteQualifiers model.bet
+            Form.SimpleBracket.isComplete model.bet
 
         topscorerComplete =
             Form.Topscorer.isComplete model.bet

--- a/src/Form/GroupMatches.elm
+++ b/src/Form/GroupMatches.elm
@@ -1,7 +1,7 @@
 module Form.GroupMatches exposing (isComplete, update, view)
 
-import Bets.Bet exposing (setMatchScore)
-import Bets.Types exposing (Answer(..), AnswerGroupMatch, Bet, Group(..), GroupMatch(..), MatchID, Score, Team)
+import Bets.SimpleBet exposing (SimpleBet, setMatchScore)
+import Bets.Types exposing (Answer(..), AnswerGroupMatch, Group(..), GroupMatch(..), MatchID, Score, Team)
 import Bets.Types.Answer.GroupMatches as GroupMatches
 import Bets.Types.Group as G
 import Bets.Types.Match as M
@@ -32,12 +32,12 @@ isWide screen =
     screen.width >= 400
 
 
-isComplete : Bet -> Bool
+isComplete : SimpleBet -> Bool
 isComplete bet =
     GroupMatches.isComplete bet.answers.matches
 
 
-update : Msg -> State -> Bet -> ( Bet, State, Cmd Msg )
+update : Msg -> State -> SimpleBet -> ( SimpleBet, State, Cmd Msg )
 update action state bet =
     let
         allMatchIDs =
@@ -156,7 +156,7 @@ groupOfMatch ( _, Answer (GroupMatch grp _ _) _ ) =
     grp
 
 
-view : Screen.Size -> Bet -> State -> Element.Element Msg
+view : Screen.Size -> SimpleBet -> State -> Element.Element Msg
 view screen bet state =
     let
         allMatches =
@@ -292,7 +292,7 @@ buildWindow cursor allMatches =
     [ above0, above1, above2, activeEntry, below0, below1, below2 ]
 
 
-viewScrollWheel : Screen.Size -> Bet -> State -> Element.Element Msg
+viewScrollWheel : Screen.Size -> SimpleBet -> State -> Element.Element Msg
 viewScrollWheel screen bet state =
     let
         allMatches =
@@ -536,7 +536,7 @@ viewGroupSeparator_ label =
 -- Group Nav
 
 
-viewGroupNav : Screen.Size -> Bet -> State -> Element.Element Msg
+viewGroupNav : Screen.Size -> SimpleBet -> State -> Element.Element Msg
 viewGroupNav screen bet state =
     let
         allGroups =
@@ -625,7 +625,7 @@ viewGroupNav screen bet state =
 -- Progress
 
 
-viewProgress : Bet -> Element.Element Msg
+viewProgress : SimpleBet -> Element.Element Msg
 viewProgress bet =
     let
         total =

--- a/src/Form/Info.elm
+++ b/src/Form/Info.elm
@@ -4,7 +4,7 @@ module Form.Info exposing
     , view
     )
 
-import Bets.Types exposing (Bet)
+import Bets.SimpleBet exposing (SimpleBet)
 import Bets.Types.Group as Group
 import Bets.Types.Round as Round
 import Element exposing (fill, spacing, width)
@@ -18,7 +18,7 @@ type alias Msg =
     FormInfoMsg
 
 
-update : Msg -> Bet -> ( Bet, Cmd Msg )
+update : Msg -> SimpleBet -> ( SimpleBet, Cmd Msg )
 update act bet =
     case act of
         NoOps ->

--- a/src/Form/Participant.elm
+++ b/src/Form/Participant.elm
@@ -4,8 +4,8 @@ module Form.Participant exposing
     , view
     )
 
-import Bets.Bet exposing (setParticipant)
-import Bets.Types exposing (Bet, StringField(..))
+import Bets.SimpleBet exposing (SimpleBet, setParticipant)
+import Bets.Types exposing (StringField(..))
 import Bets.Types.Participant
 import Element exposing (fill, spacing, width)
 import Element.Font as Font
@@ -21,7 +21,7 @@ import UI.Style
 import UI.Text
 
 
-update : Msg -> State -> Bet -> ( Bet, State, Cmd Msg )
+update : Msg -> State -> SimpleBet -> ( SimpleBet, State, Cmd Msg )
 update msg state bet =
     let
         toStringField s =
@@ -77,7 +77,7 @@ update msg state bet =
             ( bet, { state | activeField = Nothing }, Cmd.none )
 
 
-view : State -> Bet -> Element.Element Msg
+view : State -> SimpleBet -> Element.Element Msg
 view _ bet =
     let
         keys =
@@ -163,6 +163,6 @@ view _ bet =
         (header :: introduction :: [ Element.column [ Element.spacing 12, width fill ] lines ])
 
 
-isComplete : Bet -> Bool
+isComplete : SimpleBet -> Bool
 isComplete bet =
     Bets.Types.Participant.isComplete bet.participant

--- a/src/Form/SimpleBracket.elm
+++ b/src/Form/SimpleBracket.elm
@@ -1,0 +1,102 @@
+module Form.SimpleBracket exposing (isComplete, update, view)
+
+import Bets.SimpleBet as SimpleBet exposing (SimpleBet)
+import Bets.Types exposing (HasQualified(..), Round(..), Team)
+import Bets.Types.Answer.SimpleBracket as SBracket
+import Bets.Types.SimpleBracket exposing (SimpleBracket, SimpleBracketEntry)
+import Element
+import Form.SimpleBracket.Types exposing (Msg(..), State, nextRound, prevRound)
+import Form.SimpleBracket.View
+
+
+isComplete : SimpleBet -> Bool
+isComplete bet =
+    SBracket.isComplete bet.answers.bracket
+
+
+update : Msg -> SimpleBet -> State -> ( SimpleBet, State, Cmd Msg )
+update msg bet state =
+    case msg of
+        SelectTeam round team ->
+            let
+                currentBracket =
+                    SimpleBet.getSimpleBracket bet
+
+                newBracket =
+                    addEntry round team currentBracket
+
+                newBet =
+                    SimpleBet.updateSimpleBracket bet newBracket
+            in
+            ( newBet, state, Cmd.none )
+
+        DeselectTeam round team ->
+            let
+                currentBracket =
+                    SimpleBet.getSimpleBracket bet
+
+                newBracket =
+                    removeEntryAndAbove round team currentBracket
+
+                newBet =
+                    SimpleBet.updateSimpleBracket bet newBracket
+            in
+            ( newBet, state, Cmd.none )
+
+        GoNext ->
+            ( bet, { state | currentRound = nextRound state.currentRound }, Cmd.none )
+
+        GoPrev ->
+            ( bet, { state | currentRound = prevRound state.currentRound }, Cmd.none )
+
+        JumpToRound round ->
+            ( bet, { state | currentRound = round }, Cmd.none )
+
+
+view : SimpleBet -> State -> Element.Element Msg
+view bet state =
+    Form.SimpleBracket.View.view bet state
+
+
+
+-- Helpers
+
+
+roundInt : Round -> Int
+roundInt round =
+    case round of
+        R1 ->
+            1
+
+        R2 ->
+            2
+
+        R3 ->
+            3
+
+        R4 ->
+            4
+
+        R5 ->
+            5
+
+        R6 ->
+            6
+
+
+addEntry : Round -> Team -> SimpleBracket -> SimpleBracket
+addEntry round team bracket =
+    if List.any (\e -> e.team.teamID == team.teamID && e.round == round) bracket then
+        bracket
+
+    else
+        bracket ++ [ { team = team, round = round, hasQualified = TBD } ]
+
+
+removeEntryAndAbove : Round -> Team -> SimpleBracket -> SimpleBracket
+removeEntryAndAbove round team bracket =
+    List.filter
+        (\e ->
+            not (e.team.teamID == team.teamID && roundInt e.round >= roundInt round)
+        )
+        bracket

--- a/src/Form/SimpleBracket/Types.elm
+++ b/src/Form/SimpleBracket/Types.elm
@@ -1,0 +1,239 @@
+module Form.SimpleBracket.Types exposing
+    ( Msg(..)
+    , State
+    , canSelectTeam
+    , countGroupInList
+    , countGroupsWithThree
+    , init
+    , maxGroupsWithThree
+    , nextRound
+    , prevRound
+    , roundLabel
+    , roundRequired
+    , teamsInRound
+    )
+
+import Bets.Types exposing (Group, Round(..), Team, TeamData)
+import Bets.Types.Group as Group
+import Bets.Types.SimpleBracket exposing (SimpleBracket)
+import List.Extra
+import UI.Screen as Screen
+
+
+type alias State =
+    { currentRound : Round
+    , screen : Screen.Size
+    }
+
+
+type Msg
+    = SelectTeam Round Team
+    | DeselectTeam Round Team
+    | GoNext
+    | GoPrev
+    | JumpToRound Round
+
+
+init : Screen.Size -> State
+init sz =
+    { currentRound = R1
+    , screen = sz
+    }
+
+
+nextRound : Round -> Round
+nextRound round =
+    case round of
+        R1 ->
+            R2
+
+        R2 ->
+            R3
+
+        R3 ->
+            R4
+
+        R4 ->
+            R5
+
+        R5 ->
+            R6
+
+        R6 ->
+            R6
+
+
+prevRound : Round -> Round
+prevRound round =
+    case round of
+        R1 ->
+            R1
+
+        R2 ->
+            R1
+
+        R3 ->
+            R2
+
+        R4 ->
+            R3
+
+        R5 ->
+            R4
+
+        R6 ->
+            R5
+
+
+roundRequired : Round -> Int
+roundRequired round =
+    case round of
+        R1 ->
+            32
+
+        R2 ->
+            16
+
+        R3 ->
+            8
+
+        R4 ->
+            4
+
+        R5 ->
+            2
+
+        R6 ->
+            1
+
+
+roundLabel : Round -> String
+roundLabel round =
+    case round of
+        R1 ->
+            "R32"
+
+        R2 ->
+            "R16"
+
+        R3 ->
+            "KF"
+
+        R4 ->
+            "HF"
+
+        R5 ->
+            "F"
+
+        R6 ->
+            "\u{2605}"
+
+
+teamsInRound : Round -> SimpleBracket -> List Team
+teamsInRound round bracket =
+    bracket
+        |> List.filter (\e -> e.round == round)
+        |> List.map .team
+
+
+prevRoundOf : Round -> Maybe Round
+prevRoundOf round =
+    case round of
+        R1 ->
+            Nothing
+
+        R2 ->
+            Just R1
+
+        R3 ->
+            Just R2
+
+        R4 ->
+            Just R3
+
+        R5 ->
+            Just R4
+
+        R6 ->
+            Just R5
+
+
+canSelectTeam : Round -> Team -> SimpleBracket -> TeamData -> Bool
+canSelectTeam round team bracket teamData =
+    let
+        currentTeams =
+            teamsInRound round bracket
+
+        hasCapacity =
+            List.length currentTeams < roundRequired round
+
+        notAlreadyInRound =
+            not (List.any (\t -> t.teamID == team.teamID) currentTeams)
+
+        poolOk =
+            case round of
+                R1 ->
+                    let
+                        teamGroup =
+                            List.head (List.filter (\td -> td.team.teamID == team.teamID) teamData)
+                                |> Maybe.map .group
+                    in
+                    case teamGroup of
+                        Just grp ->
+                            let
+                                groupCount =
+                                    countGroupInList grp currentTeams teamData
+                            in
+                            if groupCount >= 3 then
+                                False
+
+                            else if groupCount == 2 then
+                                countGroupsWithThree currentTeams teamData < maxGroupsWithThree teamData
+
+                            else
+                                True
+
+                        Nothing ->
+                            True
+
+                _ ->
+                    case prevRoundOf round of
+                        Just prev ->
+                            List.any (\t -> t.teamID == team.teamID) (teamsInRound prev bracket)
+
+                        Nothing ->
+                            True
+    in
+    hasCapacity && notAlreadyInRound && poolOk
+
+
+countGroupInList : Group -> List Team -> TeamData -> Int
+countGroupInList grp teams teamData =
+    let
+        inGroup t =
+            List.any (\td -> td.team.teamID == t.teamID && td.group == grp) teamData
+    in
+    List.filter inGroup teams
+        |> List.length
+
+
+maxGroupsWithThree : TeamData -> Int
+maxGroupsWithThree teamData =
+    let
+        numGroups =
+            List.map .group teamData
+                |> List.Extra.uniqueBy Group.toString
+                |> List.length
+    in
+    roundRequired R1 - numGroups * 2
+
+
+countGroupsWithThree : List Team -> TeamData -> Int
+countGroupsWithThree teams teamData =
+    let
+        allGroups =
+            List.map .group teamData
+                |> List.Extra.uniqueBy Group.toString
+    in
+    List.filter (\grp -> countGroupInList grp teams teamData >= 3) allGroups
+        |> List.length

--- a/src/Form/SimpleBracket/View.elm
+++ b/src/Form/SimpleBracket/View.elm
@@ -1,0 +1,619 @@
+module Form.SimpleBracket.View exposing (view)
+
+import Bets.Init
+import Bets.SimpleBet as SimpleBet exposing (SimpleBet)
+import Bets.Types exposing (Group(..), Round(..), Team, TeamData)
+import Bets.Types.Group as Group
+import Bets.Types.SimpleBracket exposing (SimpleBracket)
+import Bets.Types.Team as T
+import Element exposing (Element, centerX, paddingXY, spacing)
+import Element.Background as Background
+import Element.Border as Border
+import Element.Events
+import Element.Font as Font
+import Form.SimpleBracket.Types
+    exposing
+        ( Msg(..)
+        , State
+        , canSelectTeam
+        , roundLabel
+        , roundRequired
+        , teamsInRound
+        )
+import List.Extra
+import UI.Color as Color
+import UI.Font
+import UI.Page exposing (page)
+import UI.Screen as Screen
+import UI.Style
+import UI.Text
+
+
+view : SimpleBet -> State -> Element Msg
+view bet state =
+    let
+        bracket =
+            SimpleBet.getSimpleBracket bet
+
+        teamData_ =
+            Bets.Init.teamData
+
+        allGroups =
+            [ A, B, C, D, E, F, G, H, I, J, K, L ]
+
+        activeRound =
+            state.currentRound
+
+        dev =
+            Screen.device state.screen
+
+        introduction =
+            Element.paragraph (UI.Style.introduction [])
+                [ Element.text (roundDescription activeRound) ]
+
+        section =
+            viewRoundSection activeRound bracket allGroups teamData_ dev (round state.screen.width)
+
+        extroduction =
+            Element.column (UI.Style.introduction [ spacing 16, Element.width Element.fill ])
+                [ UI.Text.bulletText "1 punt voor ieder juist land in de tweede ronde. "
+                , UI.Text.bulletText "4 punten per kwartfinalist. "
+                , UI.Text.bulletText "7 punten per halve finalist. "
+                , UI.Text.bulletText "10 punten per finalist. "
+                , UI.Text.bulletText "13 punten voor de kampioen. "
+                ]
+    in
+    page "bracket"
+        [ UI.Text.displayHeader (roundTitle activeRound)
+        , introduction
+        , viewStepper activeRound bracket
+        , section
+        , extroduction
+        ]
+
+
+viewRoundSection : Round -> SimpleBracket -> List Group -> TeamData -> Screen.Device -> Int -> Element Msg
+viewRoundSection activeRound bracket allGroups teamData_ dev screenWidth =
+    let
+        teams =
+            teamsInRound activeRound bracket
+
+        n =
+            List.length teams
+
+        cap =
+            roundRequired activeRound
+
+        isComplete =
+            n >= cap
+
+        counterText =
+            if isComplete then
+                String.fromInt n ++ "/" ++ String.fromInt cap ++ " geselecteerd \u{2713}"
+
+            else
+                String.fromInt n ++ "/" ++ String.fromInt cap ++ " geselecteerd"
+    in
+    Element.column [ spacing 12, Element.width Element.fill ]
+        [ Element.el
+            [ Font.color Color.grey
+            , UI.Font.mono
+            , Font.size UI.Font.captionSize
+            , centerX
+            ]
+            (Element.text counterText)
+        , viewActiveGrid activeRound bracket allGroups teamData_ dev screenWidth
+        ]
+
+
+viewStepper : Round -> SimpleBracket -> Element Msg
+viewStepper activeRound bracket =
+    let
+        allRounds =
+            [ R1, R2, R3, R4, R5, R6 ]
+
+        isRoundComplete r =
+            List.length (teamsInRound r bracket) >= roundRequired r
+
+        dotColor r =
+            if isRoundComplete r then
+                Color.green
+
+            else if r == activeRound then
+                Color.orange
+
+            else
+                Color.grey
+
+        dotBg r =
+            if isRoundComplete r || r == activeRound then
+                Background.color (dotColor r)
+
+            else
+                Border.color Color.terminalBorder
+
+        dot r =
+            Element.el
+                [ Element.width (Element.px 9)
+                , Element.height (Element.px 9)
+                , Border.rounded 50
+                , Border.width 1
+                , dotBg r
+                , Element.Events.onClick (JumpToRound r)
+                , Element.pointer
+                ]
+                Element.none
+
+        viewNode r =
+            let
+                lbl =
+                    roundLabel r
+            in
+            Element.column
+                [ Element.spacing 3
+                , Element.Events.onClick (JumpToRound r)
+                , Element.pointer
+                , Element.paddingXY 8 6
+                , Element.height (Element.px 44)
+                ]
+                [ Element.el [ Element.centerX ] (dot r)
+                , Element.el
+                    [ Font.color (dotColor r)
+                    , UI.Font.mono
+                    , Font.size UI.Font.captionSize
+                    , Element.centerX
+                    ]
+                    (Element.text lbl)
+                ]
+
+        connector =
+            Element.el
+                [ Element.width (Element.px 12)
+                , Element.height (Element.px 1)
+                , Background.color Color.terminalBorder
+                , Element.centerY
+                ]
+                Element.none
+    in
+    Element.row [ spacing 0, centerX ]
+        (List.intersperse connector (List.map viewNode allRounds))
+
+
+viewActiveGrid : Round -> SimpleBracket -> List Group -> TeamData -> Screen.Device -> Int -> Element Msg
+viewActiveGrid activeRound bracket allGroups teamData_ dev screenWidth =
+    case dev of
+        Screen.Phone ->
+            case activeRound of
+                R1 ->
+                    viewR32Grid activeRound bracket allGroups teamData_
+
+                _ ->
+                    viewFlatGrid activeRound bracket teamData_ screenWidth
+
+        Screen.Computer ->
+            case activeRound of
+                R1 ->
+                    Element.column [ spacing 12, centerX ]
+                        (List.map (viewGroup activeRound bracket (teamsInRound activeRound bracket) teamData_) allGroups)
+
+                _ ->
+                    viewFlatGrid activeRound bracket teamData_ screenWidth
+
+
+viewR32Grid : Round -> SimpleBracket -> List Group -> TeamData -> Element Msg
+viewR32Grid activeRound bracket allGroups teamData_ =
+    let
+        viewGroupSection grp =
+            let
+                members =
+                    Bets.Init.groupMembers grp
+
+                groupLabel =
+                    Element.el
+                        [ Font.color Color.terminalAccentDim
+                        , UI.Font.mono
+                        , Font.size UI.Font.captionSize
+                        , Element.width (Element.px 18)
+                        , Element.centerY
+                        ]
+                        (UI.Text.allCenteredText (Group.toString grp))
+
+                teamCells =
+                    List.map (viewCompactBadge activeRound bracket teamData_) members
+
+                badgeGrid =
+                    Element.wrappedRow [ spacing 6, Element.width Element.fill ] teamCells
+            in
+            Element.row [ spacing 6, Element.width Element.fill ] [ groupLabel, badgeGrid ]
+    in
+    Element.column [ spacing 10, centerX ] (List.map viewGroupSection allGroups)
+
+
+viewFlatGrid : Round -> SimpleBracket -> TeamData -> Int -> Element Msg
+viewFlatGrid activeRound bracket teamData_ screenWidth =
+    let
+        cols =
+            case activeRound of
+                R2 ->
+                    4
+
+                R6 ->
+                    1
+
+                _ ->
+                    2
+
+        hPad =
+            if screenWidth < 500 then
+                8
+
+            else
+                24
+
+        containerWidth =
+            min 600 screenWidth - 2 * hPad
+
+        gapBudget =
+            (cols - 1) * 12
+
+        badgeWidth =
+            max 150 ((containerWidth - gapBudget) // cols)
+
+        badgeFn =
+            case activeRound of
+                R2 ->
+                    viewCompactBadge activeRound bracket teamData_
+
+                _ ->
+                    viewWideBadge badgeWidth activeRound bracket teamData_
+
+        plausible =
+            case activeRound of
+                R1 ->
+                    []
+
+                R2 ->
+                    List.sortBy .teamID (teamsInRound R1 bracket)
+
+                R3 ->
+                    List.sortBy .teamName (teamsInRound R2 bracket)
+
+                R4 ->
+                    List.sortBy .teamName (teamsInRound R3 bracket)
+
+                R5 ->
+                    List.sortBy .teamName (teamsInRound R4 bracket)
+
+                R6 ->
+                    List.sortBy .teamName (teamsInRound R5 bracket)
+
+        cells =
+            List.map badgeFn plausible
+
+        rowSpacing =
+            case activeRound of
+                R2 ->
+                    6
+
+                _ ->
+                    12
+
+        rows =
+            List.Extra.greedyGroupsOf cols cells
+                |> List.map (\chunk -> Element.row [ spacing rowSpacing, Element.width Element.fill ] chunk)
+    in
+    Element.column [ spacing 8, centerX ] rows
+
+
+viewCompactBadge : Round -> SimpleBracket -> TeamData -> Team -> Element Msg
+viewCompactBadge activeRound bracket _ team =
+    let
+        isInRound =
+            List.any (\t -> t.teamID == team.teamID) (teamsInRound activeRound bracket)
+
+        canSelect =
+            canSelectTeam activeRound team bracket Bets.Init.teamData
+
+        flagImg =
+            Element.image
+                [ Element.height (Element.px 15)
+                , Element.width (Element.px 20)
+                ]
+                { src = T.flagUrl (Just team)
+                , description = T.display team
+                }
+
+        textColor =
+            if isInRound then
+                Color.orange
+
+            else if not canSelect then
+                Color.grey
+
+            else
+                Color.primaryText
+
+        content =
+            Element.row
+                [ spacing 4, Element.centerX, Element.centerY ]
+                [ flagImg
+                , Element.el
+                    [ UI.Font.mono
+                    , Font.color textColor
+                    , Font.size UI.Font.captionSize
+                    ]
+                    (Element.text (T.display team))
+                ]
+
+        borderColor =
+            if isInRound then
+                Color.green
+
+            else
+                Color.terminalBorder
+
+        baseAttrs =
+            [ Element.width (Element.px 68)
+            , Element.height (Element.px 34)
+            , Background.color Color.primaryDark
+            , Border.width 1
+            , Border.rounded 2
+            , Border.color borderColor
+            , paddingXY 6 4
+            ]
+    in
+    if isInRound then
+        Element.el
+            (baseAttrs
+                ++ [ Element.Events.onClick (DeselectTeam activeRound team)
+                   , Element.pointer
+                   ]
+            )
+            content
+
+    else if canSelect then
+        Element.el
+            (baseAttrs
+                ++ [ Element.Events.onClick (SelectTeam activeRound team)
+                   , Element.pointer
+                   , Element.mouseOver [ Border.color Color.orange ]
+                   ]
+            )
+            content
+
+    else
+        Element.el baseAttrs content
+
+
+viewWideBadge : Int -> Round -> SimpleBracket -> TeamData -> Team -> Element Msg
+viewWideBadge badgeWidth activeRound bracket _ team =
+    let
+        isInRound =
+            List.any (\t -> t.teamID == team.teamID) (teamsInRound activeRound bracket)
+
+        canSelect =
+            canSelectTeam activeRound team bracket Bets.Init.teamData
+
+        flagImg =
+            Element.image
+                [ Element.height (Element.px 20)
+                , Element.width (Element.px 28)
+                ]
+                { src = T.flagUrl (Just team)
+                , description = T.display team
+                }
+
+        nameColor =
+            if isInRound then
+                Color.orange
+
+            else if not canSelect then
+                Color.grey
+
+            else
+                Color.primaryText
+
+        codeColor =
+            if isInRound then
+                Color.activeNav
+
+            else
+                Color.grey
+
+        content =
+            Element.row
+                [ spacing 8
+                , Element.centerY
+                , Element.width Element.fill
+                ]
+                [ flagImg
+                , Element.column
+                    [ spacing 2, Element.width Element.fill ]
+                    [ Element.paragraph
+                        [ UI.Font.mono
+                        , Font.color nameColor
+                        , Font.size UI.Font.bodySize
+                        , Font.medium
+                        , Element.width Element.fill
+                        ]
+                        [ Element.text (T.displayFull team) ]
+                    , Element.el
+                        [ UI.Font.mono
+                        , Font.color codeColor
+                        , Font.size UI.Font.captionSize
+                        ]
+                        (Element.text (String.toLower (T.display team)))
+                    ]
+                ]
+
+        borderColor =
+            if isInRound then
+                Color.green
+
+            else
+                Color.terminalBorder
+
+        baseAttrs =
+            [ Element.width (Element.px badgeWidth)
+            , Element.height (Element.px 44)
+            , Background.color Color.primaryDark
+            , Border.width 1
+            , Border.rounded 2
+            , Border.color borderColor
+            , paddingXY 8 8
+            ]
+    in
+    if isInRound then
+        Element.el
+            (baseAttrs
+                ++ [ Element.Events.onClick (DeselectTeam activeRound team)
+                   , Element.pointer
+                   ]
+            )
+            content
+
+    else if canSelect then
+        Element.el
+            (baseAttrs
+                ++ [ Element.Events.onClick (SelectTeam activeRound team)
+                   , Element.pointer
+                   , Element.mouseOver [ Border.color Color.orange ]
+                   ]
+            )
+            content
+
+    else
+        Element.el baseAttrs content
+
+
+viewGroup : Round -> SimpleBracket -> List Team -> TeamData -> Group -> Element Msg
+viewGroup activeRound bracket placed teamData_ grp =
+    let
+        allTeams =
+            Bets.Init.groupMembers grp
+
+        isPlaced t =
+            List.any (\p -> p.teamID == t.teamID) placed
+
+        viewTeamOrBlank t =
+            if isPlaced t then
+                viewCompactBadge activeRound bracket teamData_ t
+
+            else
+                viewTeamBadge activeRound bracket teamData_ t
+
+        label =
+            Element.el
+                [ Font.color Color.terminalAccentDim
+                , UI.Font.mono
+                , Font.size UI.Font.captionSize
+                , Element.width (Element.px 18)
+                , Element.height (Element.px 34)
+                ]
+                (UI.Text.allCenteredText (Group.toString grp))
+
+        teamCodes =
+            List.map viewTeamOrBlank allTeams
+    in
+    Element.row [ spacing 6, centerX ]
+        (label :: teamCodes)
+
+
+viewTeamBadge : Round -> SimpleBracket -> TeamData -> Team -> Element Msg
+viewTeamBadge activeRound bracket teamData_ team =
+    let
+        flagImg =
+            Element.image
+                [ Element.height (Element.px 15)
+                , Element.width (Element.px 20)
+                ]
+                { src = T.flagUrl (Just team)
+                , description = T.display team
+                }
+
+        codeEl cellColor =
+            Element.el
+                [ UI.Font.mono
+                , Font.color cellColor
+                , Font.size UI.Font.captionSize
+                , Font.medium
+                ]
+                (Element.text (T.display team))
+
+        innerRow cellColor =
+            Element.row
+                [ spacing 4, Element.centerX, Element.centerY ]
+                [ flagImg, codeEl cellColor ]
+    in
+    if canSelectTeam activeRound team bracket teamData_ then
+        Element.el
+            [ Element.Events.onClick (SelectTeam activeRound team)
+            , Element.pointer
+            , Element.width (Element.px 68)
+            , Element.height (Element.px 34)
+            , Element.centerY
+            , Background.color Color.primaryDark
+            , Border.width 1
+            , Border.rounded 2
+            , Border.color Color.terminalBorder
+            , paddingXY 6 4
+            , Element.mouseOver [ Border.color Color.orange ]
+            ]
+            (innerRow Color.primaryText)
+
+    else
+        Element.el
+            [ Element.width (Element.px 68)
+            , Element.height (Element.px 34)
+            , Element.centerY
+            , Background.color Color.primaryDark
+            , Border.width 1
+            , Border.rounded 2
+            , Border.color Color.terminalBorder
+            , paddingXY 6 4
+            ]
+            (innerRow Color.grey)
+
+
+roundTitle : Round -> String
+roundTitle activeRound =
+    case activeRound of
+        R6 ->
+            "Kampioen"
+
+        R5 ->
+            "Finalisten"
+
+        R4 ->
+            "Halve finale"
+
+        R3 ->
+            "Kwartfinale"
+
+        R2 ->
+            "Ronde van 16"
+
+        R1 ->
+            "Ronde van 32"
+
+
+roundDescription : Round -> String
+roundDescription activeRound =
+    case activeRound of
+        R1 ->
+            "Kies 2 landen per groep die doorgaan naar de tweede ronde"
+
+        R2 ->
+            "Kies 16 landen voor de achtste finale"
+
+        R3 ->
+            "Kies 8 kwartfinalisten"
+
+        R4 ->
+            "Kies 4 halvefinalisten"
+
+        R5 ->
+            "Kies de 2 finalisten"
+
+        R6 ->
+            "Kies de wereldkampioen"

--- a/src/Form/Submit.elm
+++ b/src/Form/Submit.elm
@@ -1,15 +1,16 @@
 module Form.Submit exposing (view)
 
-import Bets.Types exposing (Answer(..), Bet, StringField(..))
+import Bets.SimpleBet exposing (SimpleBet)
+import Bets.Types exposing (Answer(..), StringField(..))
 import Bets.Types.Answer.GroupMatch as GroupMatch
 import Element exposing (centerX, fill, px, spacing, width)
 import Element.Background as Background
 import Element.Border as Border
 import Element.Font as Font
 import Element.Input
-import Form.Bracket
 import Form.GroupMatches
 import Form.Participant
+import Form.SimpleBracket
 import Form.Topscorer
 import RemoteData exposing (RemoteData(..))
 import Types exposing (Card(..), Info(..), InputState(..), Model, Msg(..))
@@ -53,7 +54,7 @@ view model submittable =
         )
 
 
-viewSummaryBox : Bet -> Element.Element Msg
+viewSummaryBox : SimpleBet -> Element.Element Msg
 viewSummaryBox bet =
     let
         -- Groepswedstrijden
@@ -74,7 +75,7 @@ viewSummaryBox bet =
 
         -- Knock-out schema
         bracketComplete =
-            Form.Bracket.isCompleteQualifiers bet
+            Form.SimpleBracket.isComplete bet
 
         bracketValue =
             if bracketComplete then
@@ -212,7 +213,7 @@ viewSummaryBox bet =
         rowsWithDividers
 
 
-viewSubmitButton : Bool -> RemoteData.WebData Bet -> InputState -> Element.Element Msg
+viewSubmitButton : Bool -> RemoteData.WebData SimpleBet -> InputState -> Element.Element Msg
 viewSubmitButton submittable savedBet betState =
     case ( submittable, savedBet, betState ) of
         ( _, Success _, Clean ) ->
@@ -246,7 +247,7 @@ viewSubmitButton submittable savedBet betState =
                 }
 
 
-viewIncompleteNote : Bool -> RemoteData.WebData Bet -> Element.Element Msg
+viewIncompleteNote : Bool -> RemoteData.WebData SimpleBet -> Element.Element Msg
 viewIncompleteNote submittable savedBet =
     case savedBet of
         Success _ ->

--- a/src/Form/Topscorer.elm
+++ b/src/Form/Topscorer.elm
@@ -1,8 +1,8 @@
 module Form.Topscorer exposing (isComplete, update, view)
 
-import Bets.Bet exposing (getTopscorer, setTopscorer)
+import Bets.SimpleBet exposing (SimpleBet, getTopscorer, setTopscorer)
 import Bets.Init exposing (teamData)
-import Bets.Types exposing (Answer(..), Bet, Team, Topscorer)
+import Bets.Types exposing (Answer(..), Team, Topscorer)
 import Bets.Types.Answer.Topscorer
 import Bets.Types.Team as T
 import Bets.Types.Topscorer as TS
@@ -23,7 +23,7 @@ import UI.Style
 import UI.Text
 
 
-update : Msg -> Bet -> ( Bet, Cmd Msg )
+update : Msg -> SimpleBet -> ( SimpleBet, Cmd Msg )
 update msg bet =
     case msg of
         SelectPlayer player ->
@@ -67,7 +67,7 @@ update msg bet =
             ( bet, Cmd.none )
 
 
-view : String -> Bool -> Bet -> Element.Element Msg
+view : String -> Bool -> SimpleBet -> Element.Element Msg
 view searchQuery searchFocused bet =
     viewTopscorer searchQuery searchFocused (getTopscorer bet)
 
@@ -270,6 +270,6 @@ warning =
         [ Element.text "Spelers kunnen nog afvallen, of al afgevallen zijn!" ]
 
 
-isComplete : Bet -> Bool
+isComplete : SimpleBet -> Bool
 isComplete bet =
     Bets.Types.Answer.Topscorer.isComplete bet.answers.topscorer

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -1,6 +1,7 @@
 module Form.View exposing (cardLabel, view)
 
-import Bets.Bet
+import Bets.SimpleBet
+import Bets.Types exposing (Round(..))
 import Element exposing (padding, spacing)
 import Element.Background as Background
 import Element.Border as Border
@@ -13,6 +14,8 @@ import Form.Dashboard
 import Form.GroupMatches
 import Form.Info
 import Form.Participant
+import Form.SimpleBracket
+import Form.SimpleBracket.Types as SimpleBracketTypes
 import Form.Submit
 import Form.Topscorer
 import Types exposing (Card(..), Model, Msg(..))
@@ -60,7 +63,10 @@ viewCard model idx card =
         GroupMatchesCard groupMatchesState ->
             Element.map GroupMatchMsg (Form.GroupMatches.view model.screen model.bet groupMatchesState)
 
-        BracketCard bracketState ->
+        BracketCard _ ->
+            Element.none
+
+        SimpleBracketCard simpleBracketState ->
             let
                 next =
                     Basics.min (idx + 1) (List.length model.cards - 1)
@@ -68,29 +74,26 @@ viewCard model idx card =
                 prev =
                     Basics.max (idx - 1) 0
 
-                (BracketTypes.BracketWizard ws) =
-                    bracketState.bracketState
-
-                mapBracketMsg msg =
+                mapSimpleBracketMsg msg =
                     case msg of
-                        BracketTypes.GoNext ->
-                            if ws.currentPage == BracketTypes.ChampionRound then
+                        SimpleBracketTypes.GoNext ->
+                            if simpleBracketState.currentRound == R6 then
                                 NavigateTo next
 
                             else
-                                BracketMsg BracketTypes.GoNext
+                                SimpleBracketMsg SimpleBracketTypes.GoNext
 
-                        BracketTypes.GoPrev ->
-                            if ws.currentPage == BracketTypes.LastThirtyTwoRound then
+                        SimpleBracketTypes.GoPrev ->
+                            if simpleBracketState.currentRound == R1 then
                                 NavigateTo prev
 
                             else
-                                BracketMsg BracketTypes.GoPrev
+                                SimpleBracketMsg SimpleBracketTypes.GoPrev
 
                         other ->
-                            BracketMsg other
+                            SimpleBracketMsg other
             in
-            Element.map mapBracketMsg (Form.Bracket.view model.bet bracketState)
+            Element.map mapSimpleBracketMsg (Form.SimpleBracket.view model.bet simpleBracketState)
 
         TopscorerCard { searchQuery, searchFocused } ->
             Element.map TopscorerMsg (Form.Topscorer.view searchQuery searchFocused model.bet)
@@ -101,7 +104,7 @@ viewCard model idx card =
         SubmitCard ->
             let
                 submittable =
-                    Bets.Bet.isComplete model.bet
+                    Bets.SimpleBet.isComplete model.bet
             in
             Form.Submit.view model submittable
 
@@ -127,6 +130,9 @@ sectionOf card =
             GroupSection
 
         BracketCard _ ->
+            BracketSection
+
+        SimpleBracketCard _ ->
             BracketSection
 
         TopscorerCard _ ->
@@ -273,6 +279,9 @@ cardLabel card =
             "groepen"
 
         BracketCard _ ->
+            "schema"
+
+        SimpleBracketCard _ ->
             "schema"
 
         TopscorerCard _ ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,8 +3,9 @@ module Main exposing (main)
 import API.Bets
 import Activities
 import Authentication
-import Bets.Bet
 import Bets.Init
+import Bets.SimpleBet
+import Bets.Types exposing (Round(..))
 import Browser
 import Browser.Dom
 import Browser.Events as Events
@@ -15,6 +16,8 @@ import Form.GroupMatches as GroupMatches
 import Form.Info
 import Form.Participant as Participant
 import Form.Participant.Types as ParticipantTypes
+import Form.SimpleBracket as SimpleBracket
+import Form.SimpleBracket.Types as SimpleBracketTypes
 import Form.Topscorer as Topscorer
 import Form.Topscorer.Types as TopscorerTypes
 import Http
@@ -138,21 +141,24 @@ update msg model =
         FoundTimeZone tz ->
             ( { model | timeZone = tz }, Cmd.none )
 
-        BracketMsg act ->
+        BracketMsg _ ->
+            ( model, Cmd.none )
+
+        SimpleBracketMsg act ->
             let
                 mCard =
-                    Cards.getBracketCard model.cards
+                    Cards.getSimpleBracketCard model.cards
             in
             case mCard of
-                Just (BracketCard bracketState) ->
-                    Bracket.update act model.bet bracketState
+                Just (SimpleBracketCard simpleBracketState) ->
+                    SimpleBracket.update act model.bet simpleBracketState
                         |> (\( newBet, newState, fx ) ->
                                 ( { model
                                     | bet = newBet
                                     , betState = Dirty
-                                    , cards = Cards.updateBracketCard model.cards newState
+                                    , cards = Cards.updateSimpleBracketCard model.cards newState
                                   }
-                                , Cmd.map BracketMsg fx
+                                , Cmd.map SimpleBracketMsg fx
                                 )
                            )
 
@@ -317,21 +323,12 @@ update msg model =
         SubmitMsg ->
             let
                 cmd =
-                    API.Bets.placeBetFlat model.bet
+                    API.Bets.placeBetSimple model.bet
             in
             ( model, cmd )
 
-        SubmittedBet savedBet ->
-            let
-                ( newBet, nwInputState ) =
-                    case savedBet of
-                        Success b ->
-                            ( b, Clean )
-
-                        _ ->
-                            ( model.bet, Dirty )
-            in
-            ( { model | savedBet = savedBet, bet = newBet, betState = nwInputState }, Cmd.none )
+        SubmittedBet _ ->
+            ( model, Cmd.none )
 
         NoOp ->
             ( model, Cmd.none )
@@ -340,7 +337,7 @@ update msg model =
             let
                 nwState =
                     { model
-                        | bet = Bets.Init.bet
+                        | bet = Bets.Init.simpleBet
                         , savedBet = NotAsked
                         , betState = Clean
                         , idx = 0
@@ -403,14 +400,23 @@ update msg model =
             ( { model | screen = sz, cards = newCards }, Cmd.none )
 
         -- activities
-        FetchedBet bet ->
-            ( { model | savedBet = bet }, Cmd.none )
-
-        SubmittedSimpleBet _ ->
+        FetchedBet _ ->
             ( model, Cmd.none )
 
-        FetchedSimpleBet _ ->
-            ( model, Cmd.none )
+        SubmittedSimpleBet savedBet ->
+            let
+                ( newBet, newInputState ) =
+                    case savedBet of
+                        Success b ->
+                            ( b, Clean )
+
+                        _ ->
+                            ( model.bet, Dirty )
+            in
+            ( { model | savedBet = savedBet, bet = newBet, betState = newInputState }, Cmd.none )
+
+        FetchedSimpleBet savedBet ->
+            ( { model | savedBet = savedBet }, Cmd.none )
 
         SetCommentMsg newMessage ->
             let
@@ -1015,7 +1021,7 @@ update msg model =
         BetSelected uuid ->
             let
                 cmd =
-                    API.Bets.fetchBetFlat uuid
+                    API.Bets.fetchBetSimple uuid
             in
             ( model, cmd )
 
@@ -1074,30 +1080,21 @@ update msg model =
             let
                 newBet1 =
                     List.foldl
-                        (\( matchID, score ) b -> Bets.Bet.setMatchScore b matchID score)
+                        (\( matchID, score ) b -> Bets.SimpleBet.setMatchScore b matchID score)
                         model.bet
                         TestData.Bet.dummyGroupScores
 
-                newBracket =
-                    Bracket.rebuildBracket TestData.Bet.dummyRoundSelections Bets.Init.teamData
-
                 newBet2 =
-                    Bracket.updateBracket newBet1 newBracket
+                    Bets.SimpleBet.updateSimpleBracket newBet1 TestData.Bet.dummySimpleBracket
 
                 newBet3 =
-                    Bets.Bet.setTopscorer newBet2 TestData.Bet.dummyTopscorer
+                    Bets.SimpleBet.setTopscorer newBet2 TestData.Bet.dummyTopscorer
 
-                newBracketState =
-                    { screen = model.screen
-                    , bracketState =
-                        BracketWizard
-                            { selections = TestData.Bet.dummyRoundSelections
-                            , currentPage = LastThirtyTwoRound
-                            }
-                    }
+                newSimpleBracketState =
+                    { currentRound = R1, screen = model.screen }
 
                 newCards =
-                    Cards.updateBracketCard model.cards newBracketState
+                    Cards.updateSimpleBracketCard model.cards newSimpleBracketState
             in
             ( { model
                 | bet = newBet3

--- a/src/TestData/Bet.elm
+++ b/src/TestData/Bet.elm
@@ -12,7 +12,7 @@ dummySimpleBracket =
     , entry south_africa.team R1
     , entry south_korea.team R1
     , entry canada.team R1
-    , entry team_b2.team R1
+    , entry bosnia.team R1
     , entry qatar.team R1
     , entry brazil.team R1
     , entry morocco.team R1
@@ -25,7 +25,7 @@ dummySimpleBracket =
     , entry ivory_coast.team R1
     , entry netherlands.team R1
     , entry japan.team R1
-    , entry team_f3.team R1
+    , entry sweden.team R1
     , entry belgium.team R1
     , entry egypt.team R1
     , entry iran.team R1
@@ -37,7 +37,7 @@ dummySimpleBracket =
     , entry argentina.team R1
     , entry algeria.team R1
     , entry portugal.team R1
-    , entry team_k2.team R1
+    , entry dr_congo.team R1
     , entry england.team R1
     , entry croatia.team R1
     -- R2: 16 teams

--- a/src/TestData/Bet.elm
+++ b/src/TestData/Bet.elm
@@ -1,114 +1,87 @@
-module TestData.Bet exposing (dummyGroupScores, dummyRoundSelections, dummyTopscorer)
+module TestData.Bet exposing (dummyGroupScores, dummySimpleBracket, dummyTopscorer)
 
-import Bets.Types exposing (Team, Topscorer)
+import Bets.Types exposing (HasQualified(..), Round(..), Team, Topscorer)
+import Bets.Types.SimpleBracket exposing (SimpleBracket, SimpleBracketEntry)
 import Bets.Init.WorldCup2026.Tournament.Teams exposing (..)
-import Form.Bracket.Types exposing (RoundSelections, SelectionRound(..), addTeamToRound, emptyRoundSelections)
 
 
--- dummyRoundSelections : RoundSelections
---
--- lastThirtyTwo: 2 from each of 12 groups (24 teams) + 8 third-place teams from groups A-H
---
--- Group thirds: A=south_korea, B=qatar, C=haiti, D=australia, E=ivory_coast, F=team_f3, G=iran, H=saudi_arabia
---
--- Top-2 per group:
---   A: mexico, south_africa
---   B: canada, team_b2
---   C: brazil, morocco
---   D: usa, paraguay
---   E: germany, curacao
---   F: netherlands, japan
---   G: belgium, egypt
---   H: spain, cape_verde
---   I: france, senegal
---   J: argentina, algeria
---   K: portugal, team_k2
---   L: england, croatia
+dummySimpleBracket : SimpleBracket
+dummySimpleBracket =
+    -- R1: 32 teams (2 per group A-L + 8 best thirds from groups A-H)
+    [ entry mexico.team R1
+    , entry south_africa.team R1
+    , entry south_korea.team R1
+    , entry canada.team R1
+    , entry team_b2.team R1
+    , entry qatar.team R1
+    , entry brazil.team R1
+    , entry morocco.team R1
+    , entry haiti.team R1
+    , entry usa.team R1
+    , entry paraguay.team R1
+    , entry australia.team R1
+    , entry germany.team R1
+    , entry curacao.team R1
+    , entry ivory_coast.team R1
+    , entry netherlands.team R1
+    , entry japan.team R1
+    , entry team_f3.team R1
+    , entry belgium.team R1
+    , entry egypt.team R1
+    , entry iran.team R1
+    , entry spain.team R1
+    , entry cape_verde.team R1
+    , entry saudi_arabia.team R1
+    , entry france.team R1
+    , entry senegal.team R1
+    , entry argentina.team R1
+    , entry algeria.team R1
+    , entry portugal.team R1
+    , entry team_k2.team R1
+    , entry england.team R1
+    , entry croatia.team R1
+    -- R2: 16 teams
+    , entry france.team R2
+    , entry argentina.team R2
+    , entry germany.team R2
+    , entry netherlands.team R2
+    , entry spain.team R2
+    , entry england.team R2
+    , entry brazil.team R2
+    , entry portugal.team R2
+    , entry usa.team R2
+    , entry canada.team R2
+    , entry mexico.team R2
+    , entry belgium.team R2
+    , entry ivory_coast.team R2
+    , entry senegal.team R2
+    , entry australia.team R2
+    , entry croatia.team R2
+    -- R3: 8 teams (quarters)
+    , entry france.team R3
+    , entry argentina.team R3
+    , entry germany.team R3
+    , entry spain.team R3
+    , entry england.team R3
+    , entry brazil.team R3
+    , entry portugal.team R3
+    , entry netherlands.team R3
+    -- R4: 4 teams (semis)
+    , entry france.team R4
+    , entry germany.team R4
+    , entry spain.team R4
+    , entry brazil.team R4
+    -- R5: 2 teams (finalists)
+    , entry france.team R5
+    , entry brazil.team R5
+    -- R6: champion
+    , entry france.team R6
+    ]
 
 
-dummyRoundSelections : RoundSelections
-dummyRoundSelections =
-    emptyRoundSelections
-        -- lastThirtyTwo: Group A top 2 + 3rd
-        |> addTeamToRound LastThirtyTwoRound mexico.team
-        |> addTeamToRound LastThirtyTwoRound south_africa.team
-        |> addTeamToRound LastThirtyTwoRound south_korea.team
-        -- Group B top 2 + 3rd
-        |> addTeamToRound LastThirtyTwoRound canada.team
-        |> addTeamToRound LastThirtyTwoRound team_b2.team
-        |> addTeamToRound LastThirtyTwoRound qatar.team
-        -- Group C top 2 + 3rd
-        |> addTeamToRound LastThirtyTwoRound brazil.team
-        |> addTeamToRound LastThirtyTwoRound morocco.team
-        |> addTeamToRound LastThirtyTwoRound haiti.team
-        -- Group D top 2 + 3rd
-        |> addTeamToRound LastThirtyTwoRound usa.team
-        |> addTeamToRound LastThirtyTwoRound paraguay.team
-        |> addTeamToRound LastThirtyTwoRound australia.team
-        -- Group E top 2 + 3rd
-        |> addTeamToRound LastThirtyTwoRound germany.team
-        |> addTeamToRound LastThirtyTwoRound curacao.team
-        |> addTeamToRound LastThirtyTwoRound ivory_coast.team
-        -- Group F top 2 + 3rd
-        |> addTeamToRound LastThirtyTwoRound netherlands.team
-        |> addTeamToRound LastThirtyTwoRound japan.team
-        |> addTeamToRound LastThirtyTwoRound team_f3.team
-        -- Group G top 2 + 3rd
-        |> addTeamToRound LastThirtyTwoRound belgium.team
-        |> addTeamToRound LastThirtyTwoRound egypt.team
-        |> addTeamToRound LastThirtyTwoRound iran.team
-        -- Group H top 2 + 3rd
-        |> addTeamToRound LastThirtyTwoRound spain.team
-        |> addTeamToRound LastThirtyTwoRound cape_verde.team
-        |> addTeamToRound LastThirtyTwoRound saudi_arabia.team
-        -- Group I top 2 (no 3rd — only A-H supply thirds)
-        |> addTeamToRound LastThirtyTwoRound france.team
-        |> addTeamToRound LastThirtyTwoRound senegal.team
-        -- Group J top 2
-        |> addTeamToRound LastThirtyTwoRound argentina.team
-        |> addTeamToRound LastThirtyTwoRound algeria.team
-        -- Group K top 2
-        |> addTeamToRound LastThirtyTwoRound portugal.team
-        |> addTeamToRound LastThirtyTwoRound team_k2.team
-        -- Group L top 2
-        |> addTeamToRound LastThirtyTwoRound england.team
-        |> addTeamToRound LastThirtyTwoRound croatia.team
-        -- lastSixteen: 16 teams that advance from R32
-        |> addTeamToRound LastSixteenRound france.team
-        |> addTeamToRound LastSixteenRound argentina.team
-        |> addTeamToRound LastSixteenRound germany.team
-        |> addTeamToRound LastSixteenRound netherlands.team
-        |> addTeamToRound LastSixteenRound spain.team
-        |> addTeamToRound LastSixteenRound england.team
-        |> addTeamToRound LastSixteenRound brazil.team
-        |> addTeamToRound LastSixteenRound portugal.team
-        |> addTeamToRound LastSixteenRound usa.team
-        |> addTeamToRound LastSixteenRound canada.team
-        |> addTeamToRound LastSixteenRound mexico.team
-        |> addTeamToRound LastSixteenRound belgium.team
-        |> addTeamToRound LastSixteenRound ivory_coast.team
-        |> addTeamToRound LastSixteenRound senegal.team
-        |> addTeamToRound LastSixteenRound australia.team
-        |> addTeamToRound LastSixteenRound croatia.team
-        -- quarters: 8 teams
-        |> addTeamToRound QuarterRound france.team
-        |> addTeamToRound QuarterRound argentina.team
-        |> addTeamToRound QuarterRound germany.team
-        |> addTeamToRound QuarterRound spain.team
-        |> addTeamToRound QuarterRound england.team
-        |> addTeamToRound QuarterRound brazil.team
-        |> addTeamToRound QuarterRound portugal.team
-        |> addTeamToRound QuarterRound netherlands.team
-        -- semis: 4 teams
-        |> addTeamToRound SemiRound france.team
-        |> addTeamToRound SemiRound germany.team
-        |> addTeamToRound SemiRound spain.team
-        |> addTeamToRound SemiRound brazil.team
-        -- finalists: 2 teams
-        |> addTeamToRound FinalistRound france.team
-        |> addTeamToRound FinalistRound brazil.team
-        -- champion
-        |> addTeamToRound ChampionRound france.team
+entry : Team -> Round -> SimpleBracketEntry
+entry team round =
+    { team = team, round = round, hasQualified = TBD }
 
 
 dummyGroupScores : List ( String, ( Maybe Int, Maybe Int ) )

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -37,6 +37,7 @@ module Types exposing
     , initPost
     )
 
+
 import Bets.Init
 import Bets.SimpleBet exposing (SimpleBet)
 import Bets.Types exposing (Bet, Group(..), Round(..), Topscorer)
@@ -45,6 +46,7 @@ import Browser.Navigation as Navigation
 import Form.Bracket.Types as Bracket
 import Form.GroupMatches.Types as GroupMatches
 import Form.Participant.Types as Participant
+import Form.SimpleBracket.Types as SimpleBracket
 import Form.Topscorer.Types as Topscorer
 import Html exposing (Html, div)
 import RemoteData exposing (RemoteData(..), WebData)
@@ -91,6 +93,7 @@ type Card
       -- | QuestionCard Questions.Model
     | GroupMatchesCard GroupMatches.State
     | BracketCard Bracket.State
+    | SimpleBracketCard SimpleBracket.State
     | TopscorerCard { searchQuery : String, searchFocused : Bool }
     | ParticipantCard Participant.State
     | SubmitCard
@@ -122,7 +125,7 @@ type InputState
 init : Maybe String -> Screen.Size -> Navigation.Key -> Model Msg
 init formId sz navKey =
     { cards = initCards sz
-    , bet = Bets.Init.bet
+    , bet = Bets.Init.simpleBet
     , savedBet = NotAsked
     , idx = 0
     , formId = formId
@@ -151,8 +154,8 @@ init formId sz navKey =
 
 type alias Model msg =
     { cards : List Card
-    , bet : Bet
-    , savedBet : WebData Bet
+    , bet : SimpleBet
+    , savedBet : WebData SimpleBet
     , idx : Page
     , formId : Maybe String
     , betState : InputState
@@ -191,6 +194,7 @@ type Msg
       -- | QuestionSetMsg Page Form.QuestionSet.Msg
     | GroupMatchMsg GroupMatches.Msg
     | BracketMsg Bracket.Msg
+    | SimpleBracketMsg SimpleBracket.Msg
     | TopscorerMsg Topscorer.Msg
     | ParticipantMsg Participant.Msg
     | SubmitMsg
@@ -292,7 +296,7 @@ initCards sz =
                     []
 
         otherCards =
-            [ BracketCard <| Bracket.init sz
+            [ SimpleBracketCard <| SimpleBracket.init sz
             , TopscorerCard { searchQuery = "", searchFocused = False }
             , ParticipantCard { activeField = Nothing }
             , SubmitCard

--- a/src/View.elm
+++ b/src/View.elm
@@ -622,6 +622,9 @@ viewStatusBar model =
                 Just (BracketCard _) ->
                     "schema"
 
+                Just (SimpleBracketCard _) ->
+                    "schema"
+
                 Just (TopscorerCard _) ->
                     "topscorer"
 


### PR DESCRIPTION
## Summary

- Wires up the WC2026 form to use `SimpleBracket`/`SimpleBet` instead of the tree-based bracket, routing through the new `/bets/simple/` API endpoints
- Replaces three placeholder team stubs (`team_b2`/`team_f3`/`team_k2`, IDs `"B2"`/`"F3"`/`"K2"`) in `TestData/Bet.elm` with the confirmed teams `bosnia`/`sweden`/`dr_congo`

## Test plan

- [ ] Build compiles without errors (`make debug`)
- [ ] Form progression works end-to-end with the SimpleBracket card
- [ ] Submit sends to `/bets/simple/` and receives a UUID back
- [ ] `dummySimpleBracket` in test data contains 32 unique real team IDs in R1

🤖 Generated with [Claude Code](https://claude.com/claude-code)